### PR TITLE
Wire desktop UI to real backend data on three surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ node_modules
 /app/dist
 /app/coverage
 /app/src-tauri/gen
+
+# `tauri icon` byproducts for non-desktop targets (config references only 32/128/128@2x)
+/app/src-tauri/icons/Square*.png
+/app/src-tauri/icons/StoreLogo.png
+/app/src-tauri/icons/android/
+/app/src-tauri/icons/ios/

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -7,8 +7,10 @@
 
 use crate::{
     AppState, BuildRequest, Collocate as CollocateDto, CollocatesRequest, CollocatesResult,
-    CorpusMeta, CorpusMetaEnvelope, KwicHit as KwicHitDto, KwicRequest, KwicResult, OpenedCorpus,
-    TaggerKind,
+    CorpusMeta, CorpusMetaEnvelope, DocTermCount as DocTermCountDto,
+    DocumentInfo as DocumentInfoDto, ExpandRequest, ExpandedContext, FreqRow, FrequenciesRequest,
+    FrequenciesResult, KwicHit as KwicHitDto, KwicRequest, KwicResult, OpenedCorpus, TaggerKind,
+    TermDistRequest, TermDistResult,
 };
 use corpust_annotate::{Annotator, treetagger::TreeTagger};
 use corpust_index::{CorpusIndex, DEFAULT_CONTEXT};
@@ -261,6 +263,7 @@ pub fn run_kwic(state: State<'_, AppState>, req: KwicRequest) -> Result<KwicResu
             .map(|h| KwicHitDto {
                 doc_id: h.doc_id,
                 path: h.path.to_string_lossy().into_owned(),
+                hit_position: h.hit_position,
                 left: h.left,
                 hit: h.hit,
                 right: h.right,
@@ -269,6 +272,129 @@ pub fn run_kwic(state: State<'_, AppState>, req: KwicRequest) -> Result<KwicResu
         elapsed_ms,
         truncated,
     })
+}
+
+/// List every document in a corpus with its path + token count. Backs
+/// the CorpusDetail document table.
+#[tauri::command]
+pub fn list_documents(
+    state: State<'_, AppState>,
+    corpus_id: String,
+) -> Result<Vec<DocumentInfoDto>, String> {
+    with_corpus(&state, &corpus_id, |index| {
+        let docs = index
+            .list_documents()
+            .map_err(|e| format!("listing documents: {e:#}"))?;
+        Ok(docs
+            .into_iter()
+            .map(|d| DocumentInfoDto {
+                doc_id: d.doc_id,
+                path: d.path.to_string_lossy().into_owned(),
+                token_count: d.token_count,
+            })
+            .collect())
+    })
+}
+
+/// Corpus-wide top-N term frequencies on a layer. Backs the FrequencyView
+/// word / POS tables.
+#[tauri::command]
+pub fn run_frequencies(
+    state: State<'_, AppState>,
+    req: FrequenciesRequest,
+) -> Result<FrequenciesResult, String> {
+    let limit = req.limit.clamp(1, 1000);
+    let t0 = Instant::now();
+    let (rows, total_tokens) = with_corpus(&state, &req.corpus_id, |index| {
+        index
+            .frequencies(req.layer.into(), limit)
+            .map_err(|e| format!("frequencies failed: {e:#}"))
+    })?;
+    let denom = total_tokens.max(1) as f64;
+    let rows = rows
+        .into_iter()
+        .map(|(term, count)| FreqRow {
+            term,
+            count,
+            pct: count as f64 / denom * 100.0,
+        })
+        .collect();
+    Ok(FrequenciesResult {
+        rows,
+        total_tokens,
+        elapsed_ms: t0.elapsed().as_secs_f64() * 1000.0,
+    })
+}
+
+/// Per-document hit counts + a corpus-wide dispersion histogram for a
+/// term. Backs the FrequencyView document table and dispersion strip.
+#[tauri::command]
+pub fn run_term_distribution(
+    state: State<'_, AppState>,
+    req: TermDistRequest,
+) -> Result<TermDistResult, String> {
+    let buckets = req.buckets.clamp(1, 1000);
+    let t0 = Instant::now();
+    let dist = with_corpus(&state, &req.corpus_id, |index| {
+        index
+            .term_distribution(&req.term, req.layer.into(), buckets)
+            .map_err(|e| format!("term distribution failed: {e:#}"))
+    })?;
+    Ok(TermDistResult {
+        doc_counts: dist
+            .doc_counts
+            .into_iter()
+            .map(|d| DocTermCountDto {
+                doc_id: d.doc_id,
+                path: d.path.to_string_lossy().into_owned(),
+                hits: d.hits,
+                token_count: d.token_count,
+            })
+            .collect(),
+        dispersion: dist.dispersion,
+        total_hits: dist.total_hits,
+        elapsed_ms: t0.elapsed().as_secs_f64() * 1000.0,
+    })
+}
+
+/// Re-expand the context around a single KWIC hit to a wider window.
+/// Backs the ContextDrawer.
+#[tauri::command]
+pub fn expand_context(
+    state: State<'_, AppState>,
+    req: ExpandRequest,
+) -> Result<ExpandedContext, String> {
+    let context = req.context.clamp(1, 500);
+    let found = with_corpus(&state, &req.corpus_id, |index| {
+        index
+            .context_at(req.doc_id, req.position, context)
+            .map_err(|e| format!("context lookup failed: {e:#}"))
+    })?;
+    // Resolve the path separately so the drawer can show a title even if
+    // the position fell out of range.
+    let path = with_corpus(&state, &req.corpus_id, |index| {
+        Ok(index
+            .list_documents()
+            .map_err(|e| format!("listing documents: {e:#}"))?
+            .into_iter()
+            .find(|d| d.doc_id == req.doc_id)
+            .map(|d| d.path.to_string_lossy().into_owned())
+            .unwrap_or_default())
+    })?;
+    match found {
+        Some((before, hit, after, token_count)) => Ok(ExpandedContext {
+            doc_id: req.doc_id,
+            path,
+            before,
+            hit,
+            after,
+            token_count,
+        }),
+        None => Err(format!(
+            "no token at position {} in doc {}",
+            req.position, req.doc_id
+        )),
+    }
 }
 
 /// Runs the build on a worker thread so the UI event loop stays

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -51,6 +51,10 @@ pub fn run() {
             commands::run_kwic,
             commands::run_collocates,
             commands::build_index,
+            commands::list_documents,
+            commands::run_frequencies,
+            commands::run_term_distribution,
+            commands::expand_context,
         ])
         .run(tauri::generate_context!())
         .expect("error while running corpust");
@@ -97,6 +101,9 @@ pub struct KwicRequest {
 pub struct KwicHit {
     pub doc_id: u64,
     pub path: String,
+    /// Token position of the hit in its document; the frontend feeds it
+    /// back to `expand_context` to widen the concordance window.
+    pub hit_position: usize,
     pub left: String,
     pub hit: String,
     pub right: String,
@@ -178,4 +185,91 @@ pub enum TaggerKind {
     /// Bundled `tree-tagger` binary; one subprocess per document.
     /// Accurate (LancsBox parity) but slow.
     Subprocess,
+}
+
+// ---- Document list (CorpusDetail) ----
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocumentInfo {
+    pub doc_id: u64,
+    pub path: String,
+    pub token_count: usize,
+}
+
+// ---- Frequency table (FrequencyView word/POS tables) ----
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrequenciesRequest {
+    pub corpus_id: String,
+    pub layer: QueryLayer,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FreqRow {
+    pub term: String,
+    pub count: u64,
+    pub pct: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrequenciesResult {
+    pub rows: Vec<FreqRow>,
+    pub total_tokens: u64,
+    pub elapsed_ms: f64,
+}
+
+// ---- Term distribution (FrequencyView per-doc table + dispersion) ----
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TermDistRequest {
+    pub corpus_id: String,
+    pub term: String,
+    pub layer: QueryLayer,
+    pub buckets: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocTermCount {
+    pub doc_id: u64,
+    pub path: String,
+    pub hits: u64,
+    pub token_count: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TermDistResult {
+    pub doc_counts: Vec<DocTermCount>,
+    pub dispersion: Vec<u32>,
+    pub total_hits: u64,
+    pub elapsed_ms: f64,
+}
+
+// ---- Context expansion (ContextDrawer) ----
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExpandRequest {
+    pub corpus_id: String,
+    pub doc_id: u64,
+    pub position: usize,
+    pub context: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExpandedContext {
+    pub doc_id: u64,
+    pub path: String,
+    pub before: String,
+    pub hit: String,
+    pub after: String,
+    pub token_count: usize,
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -132,6 +132,7 @@ export function App() {
           const hits: KwicHit[] = r.hits.map((h, i) => ({
             docId: String(h.docId),
             pos: i,
+            hitPos: h.hitPosition,
             left: h.left,
             hit: h.hit,
             right: h.right,

--- a/app/src/components/analyses/CorpusDetail.tsx
+++ b/app/src/components/analyses/CorpusDetail.tsx
@@ -1,7 +1,9 @@
 import { Download, Eye, Search } from "lucide-react";
+import { useEffect, useState } from "react";
 import { DOCUMENTS } from "@/data";
+import { type DocumentInfo, hasLiveData, listDocuments } from "@/lib/tauri";
 import type { CorpusMeta } from "@/types";
-import { formatBuildTime, formatBytes, formatDate } from "@/lib/utils";
+import { basename, formatBuildTime, formatBytes, formatDate } from "@/lib/utils";
 
 export interface CorpusDetailProps {
   corpus: CorpusMeta;
@@ -10,6 +12,27 @@ export interface CorpusDetailProps {
 
 export function CorpusDetail({ corpus, onDismiss }: CorpusDetailProps) {
   const wps = Math.round(corpus.tokenCount / (corpus.buildMs / 1000));
+
+  const [docs, setDocs] = useState<DocumentInfo[] | null>(null);
+  useEffect(() => {
+    setDocs(null);
+    if (!hasLiveData(corpus.id)) return;
+    let cancelled = false;
+    listDocuments(corpus.id)
+      .then((d) => {
+        if (!cancelled) setDocs(d);
+      })
+      .catch((e) => console.error("listDocuments failed:", e));
+    return () => {
+      cancelled = true;
+    };
+  }, [corpus.id]);
+
+  // Real corpora show filename + token count (the only per-document data
+  // the index stores). Fixtures keep their richer demo metadata.
+  const docRows = docs
+    ? docs.map((d) => ({ file: basename(d.path), tokens: d.tokenCount }))
+    : DOCUMENTS.map((d) => ({ file: d.id, tokens: d.tokens }));
   return (
     <div className="cx-detail">
       <div className="cx-detail-head">
@@ -88,25 +111,19 @@ export function CorpusDetail({ corpus, onDismiss }: CorpusDetailProps) {
 
       <div className="cx-section-h">
         <span>documents</span>
-        <span className="sub">{corpus.docCount.toLocaleString()} files · showing first 13</span>
+        <span className="sub">{docRows.length.toLocaleString()} files</span>
       </div>
       <table className="cx-doc-table">
         <thead>
           <tr>
-            <th>id</th>
-            <th>title</th>
-            <th>author</th>
-            <th className="num">year</th>
+            <th>file</th>
             <th className="num">tokens</th>
           </tr>
         </thead>
         <tbody>
-          {DOCUMENTS.map((d) => (
-            <tr key={d.id}>
-              <td style={{ color: "var(--fg-muted)" }}>{d.id}</td>
-              <td>{d.title}</td>
-              <td style={{ color: "var(--fg-muted)" }}>{d.author}</td>
-              <td className="num">{d.year}</td>
+          {docRows.map((d) => (
+            <tr key={d.file}>
+              <td style={{ color: "var(--fg-muted)" }}>{d.file}</td>
               <td className="num">{d.tokens.toLocaleString()}</td>
             </tr>
           ))}

--- a/app/src/components/analyses/FrequencyView.tsx
+++ b/app/src/components/analyses/FrequencyView.tsx
@@ -1,17 +1,105 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { DOC_FREQ, POS_FREQ, WORD_FREQ, makeDispersion } from "@/data";
-import type { CorpusMeta, FreqBy, FreqRow } from "@/types";
+import {
+  type FreqResultRow,
+  type TermDistResult,
+  hasLiveData,
+  runFrequencies,
+  runTermDistribution,
+} from "@/lib/tauri";
+import { basename } from "@/lib/utils";
+import type { CorpusMeta, FreqBy } from "@/types";
 
 export interface FrequencyViewProps {
   corpus: CorpusMeta;
   term: string;
 }
 
+/** How many bars to show in the top-terms list, and how many buckets to
+ *  split the dispersion axis into. */
+const TOP_N = 12;
+const BUCKETS = 100;
+
+interface FreqBarRow {
+  primary: string;
+  secondary?: string;
+  count: number;
+  pct: number;
+}
+
+interface DocFreqRow {
+  doc: string;
+  hits: number;
+  per1m: number;
+}
+
 export function FrequencyView({ corpus, term }: FrequencyViewProps) {
   const [by, setBy] = useState<FreqBy>("word");
-  const dispersion = useMemo(() => makeDispersion(42), []);
-  const freq: FreqRow[] = by === "pos" ? POS_FREQ : WORD_FREQ;
-  const maxCount = freq[0].count;
+  const [liveFreq, setLiveFreq] = useState<FreqResultRow[] | null>(null);
+  const [liveDist, setLiveDist] = useState<TermDistResult | null>(null);
+
+  // Corpus-wide term frequencies on the active layer; refetch when the
+  // corpus or the word/POS toggle changes. Fixtures fall through below.
+  useEffect(() => {
+    setLiveFreq(null);
+    if (!hasLiveData(corpus.id)) return;
+    let cancelled = false;
+    runFrequencies({ corpusId: corpus.id, layer: by, limit: TOP_N })
+      .then((r) => {
+        if (!cancelled) setLiveFreq(r.rows);
+      })
+      .catch((e) => console.error("runFrequencies failed:", e));
+    return () => {
+      cancelled = true;
+    };
+  }, [corpus.id, by]);
+
+  // Per-document hit counts + dispersion for the queried term.
+  useEffect(() => {
+    setLiveDist(null);
+    if (!hasLiveData(corpus.id) || !term.trim()) return;
+    let cancelled = false;
+    runTermDistribution({ corpusId: corpus.id, term: term.trim(), layer: by, buckets: BUCKETS })
+      .then((r) => {
+        if (!cancelled) setLiveDist(r);
+      })
+      .catch((e) => console.error("runTermDistribution failed:", e));
+    return () => {
+      cancelled = true;
+    };
+  }, [corpus.id, term, by]);
+
+  const fixtureDispersion = useMemo(() => makeDispersion(42), []);
+
+  // --- Normalise live or fixture data into uniform render rows. ---
+
+  const freqRows: FreqBarRow[] = liveFreq
+    ? liveFreq.map((r) => ({ primary: r.term, count: r.count, pct: r.pct }))
+    : (by === "pos" ? POS_FREQ : WORD_FREQ).map((r) => ({
+        primary: (by === "pos" ? r.tag : r.word) ?? "",
+        secondary: by === "pos" ? r.label : undefined,
+        count: r.count,
+        pct: r.pct,
+      }));
+  const maxCount = freqRows.length ? freqRows[0].count : 1;
+
+  const docFreq: DocFreqRow[] = liveDist
+    ? liveDist.docCounts.map((d) => ({
+        doc: basename(d.path),
+        hits: d.hits,
+        per1m: d.tokenCount > 0 ? (d.hits / d.tokenCount) * 1_000_000 : 0,
+      }))
+    : DOC_FREQ;
+  const maxDocHits = docFreq.length ? docFreq[0].hits : 1;
+
+  // Barcode dispersion: a mark at each non-empty bucket along the axis.
+  const dispMarks: number[] = liveDist
+    ? liveDist.dispersion.flatMap((c, i) =>
+        c > 0 ? [(i / liveDist.dispersion.length) * 100] : [],
+      )
+    : fixtureDispersion;
+  const dispHits = liveDist ? liveDist.totalHits : fixtureDispersion.length;
+  const dispBuckets = liveDist ? liveDist.dispersion.length : BUCKETS;
 
   return (
     <div className="cx-freq-wrap">
@@ -42,13 +130,12 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
             <div className="cx-card-meta">n = {corpus.tokenCount.toLocaleString()} tokens</div>
           </div>
           <div className="cx-card-body">
-            {freq.map((row) => {
+            {freqRows.map((row) => {
               const w = (row.count / maxCount) * 100;
-              const key = row.word ?? row.tag ?? "";
               return (
-                <div key={key} className="cx-freq-bar-row">
+                <div key={row.primary} className="cx-freq-bar-row">
                   <span className={`word ${by === "pos" ? "is-pos" : ""}`}>
-                    {by === "pos" ? `${row.tag} · ${row.label}` : row.word}
+                    {row.secondary ? `${row.primary} · ${row.secondary}` : row.primary}
                   </span>
                   <div className="cx-freq-bar" style={{ width: `${w}%` }} />
                   <span className="count">{row.count.toLocaleString()}</span>
@@ -64,11 +151,13 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
             <div className="cx-card-title">
               dispersion · <span style={{ fontFamily: "var(--font-mono)" }}>"{term}"</span>
             </div>
-            <div className="cx-card-meta">{dispersion.length} hits · 100 buckets</div>
+            <div className="cx-card-meta">
+              {dispHits.toLocaleString()} hits · {dispBuckets} buckets
+            </div>
           </div>
           <div className="cx-card-body">
             <div className="cx-disp">
-              {dispersion.map((pct, i) => (
+              {dispMarks.map((pct, i) => (
                 <div key={i} className="cx-disp-mark" style={{ left: `${pct}%` }} />
               ))}
             </div>
@@ -84,7 +173,7 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
               <span>top documents</span>
               <span className="sub">hits · per 1M tokens</span>
             </div>
-            {DOC_FREQ.slice(0, 8).map((d) => (
+            {docFreq.slice(0, 8).map((d) => (
               <div
                 key={d.doc}
                 className="cx-freq-bar-row"
@@ -93,10 +182,7 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
                 <span className="word" style={{ fontSize: 11 }}>
                   {d.doc}
                 </span>
-                <div
-                  className="cx-freq-bar"
-                  style={{ width: `${(d.hits / DOC_FREQ[0].hits) * 100}%` }}
-                />
+                <div className="cx-freq-bar" style={{ width: `${(d.hits / maxDocHits) * 100}%` }} />
                 <span className="count">{d.hits}</span>
                 <span className="pct">{d.per1m.toFixed(1)}/M</span>
               </div>

--- a/app/src/components/kwic/ContextDrawer.tsx
+++ b/app/src/components/kwic/ContextDrawer.tsx
@@ -3,8 +3,10 @@
 // Serif 4. 420px wide, slides in 180ms.
 
 import { ArrowLeft, ArrowRight, FileText, X } from "lucide-react";
-import { Fragment } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { EXPANDED } from "@/data";
+import { type ExpandedContext, expandContext, hasLiveData } from "@/lib/tauri";
+import { basename } from "@/lib/utils";
 import type { CorpusMeta, KwicHit } from "@/types";
 
 export interface ContextDrawerProps {
@@ -15,7 +17,52 @@ export interface ContextDrawerProps {
   onNext: () => void;
 }
 
+/** Tokens of context to fetch on each side when expanding a hit. */
+const EXPAND_CONTEXT = 45;
+
 export function ContextDrawer({ hit, corpus, onClose, onPrev, onNext }: ContextDrawerProps) {
+  const [live, setLive] = useState<ExpandedContext | null>(null);
+
+  // Pull a wider context window from the backend for real corpora. Fixture
+  // corpora fall through to the `EXPANDED` demo map below.
+  useEffect(() => {
+    setLive(null);
+    if (!hasLiveData(corpus.id) || hit.hitPos == null) return;
+    let cancelled = false;
+    expandContext({
+      corpusId: corpus.id,
+      docId: Number(hit.docId),
+      position: hit.hitPos,
+      context: EXPAND_CONTEXT,
+    })
+      .then((r) => {
+        if (!cancelled) setLive(r);
+      })
+      .catch((e) => {
+        console.error("expandContext failed:", e);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [corpus.id, hit.docId, hit.hitPos]);
+
+  if (live) {
+    return (
+      <DrawerShell
+        docTitle={basename(live.path).replace(/\.txt$/, "")}
+        docMeta={`position ${hit.hitPos?.toLocaleString() ?? "?"} of ${live.tokenCount.toLocaleString()} tokens`}
+        pos={hit.hitPos ?? hit.pos}
+        onClose={onClose}
+        onPrev={onPrev}
+        onNext={onNext}
+      >
+        <span style={{ color: "var(--fg-muted)" }}>{live.before} </span>
+        <span className="cx-drawer-hit">{live.hit}</span>
+        <span style={{ color: "var(--fg-muted)" }}> {live.after}</span>
+      </DrawerShell>
+    );
+  }
+
   const expanded = EXPANDED[`${corpus.id}|${hit.docId}|${hit.pos}`] ?? {
     before:
       "Context before the hit would appear here in three sentences, loaded lazily from the underlying document on the Rust side. The drawer renders in Source Serif 4 because at this point the user is reading rather than scanning; monospace lives in the table, serif lives here. ",
@@ -29,13 +76,47 @@ export function ContextDrawer({ hit, corpus, onClose, onPrev, onNext }: ContextD
   const parts = expanded.match.split(hit.hit);
 
   return (
+    <DrawerShell
+      docTitle={expanded.docTitle}
+      docMeta={expanded.docMeta}
+      pos={hit.pos}
+      onClose={onClose}
+      onPrev={onPrev}
+      onNext={onNext}
+    >
+      <span style={{ color: "var(--fg-muted)" }}>{expanded.before}</span>
+      <span>
+        {parts.map((part, i) => (
+          <Fragment key={i}>
+            {part}
+            {i < parts.length - 1 && <span className="cx-drawer-hit">{hit.hit}</span>}
+          </Fragment>
+        ))}
+      </span>
+      <span style={{ color: "var(--fg-muted)" }}>{expanded.after}</span>
+    </DrawerShell>
+  );
+}
+
+interface DrawerShellProps {
+  docTitle: string;
+  docMeta: string;
+  pos: number;
+  onClose: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+  children: React.ReactNode;
+}
+
+function DrawerShell({ docTitle, docMeta, pos, onClose, onPrev, onNext, children }: DrawerShellProps) {
+  return (
     <aside className="cx-drawer">
       <div className="cx-drawer-head">
         <div className="cx-drawer-title">
           <FileText size={12} />
-          <span style={{ color: "var(--fg)" }}>{expanded.docTitle}</span>
+          <span style={{ color: "var(--fg)" }}>{docTitle}</span>
           <span className="pos">·</span>
-          <span className="pos">pos {hit.pos.toLocaleString()}</span>
+          <span className="pos">pos {pos.toLocaleString()}</span>
         </div>
         <div style={{ display: "flex", gap: 4 }}>
           <button type="button" className="cx-btn cx-btn-ghost cx-btn-icon" onClick={onPrev} title="Previous hit (k)">
@@ -49,20 +130,9 @@ export function ContextDrawer({ hit, corpus, onClose, onPrev, onNext }: ContextD
           </button>
         </div>
       </div>
-      <div className="cx-drawer-body">
-        <span style={{ color: "var(--fg-muted)" }}>{expanded.before}</span>
-        <span>
-          {parts.map((part, i) => (
-            <Fragment key={i}>
-              {part}
-              {i < parts.length - 1 && <span className="cx-drawer-hit">{hit.hit}</span>}
-            </Fragment>
-          ))}
-        </span>
-        <span style={{ color: "var(--fg-muted)" }}>{expanded.after}</span>
-      </div>
+      <div className="cx-drawer-body">{children}</div>
       <div className="cx-drawer-foot">
-        <span>{expanded.docMeta}</span>
+        <span>{docMeta}</span>
         <div className="cx-drawer-nav">
           <span className="cx-kbd">j</span>
           <span>/</span>

--- a/app/src/lib/tauri.test.ts
+++ b/app/src/lib/tauri.test.ts
@@ -68,6 +68,55 @@ describe("tauri wrappers", () => {
     expect(invokeMock).toHaveBeenCalledWith("build_index", { req });
   });
 
+  it("listDocuments forwards corpusId", async () => {
+    invokeMock.mockResolvedValue([]);
+    const { listDocuments } = await import("./tauri");
+    await listDocuments("c1");
+    expect(invokeMock).toHaveBeenCalledWith("list_documents", { corpusId: "c1" });
+  });
+
+  it("runFrequencies forwards the request under `req`", async () => {
+    invokeMock.mockResolvedValue({ rows: [], totalTokens: 0, elapsedMs: 0 });
+    const { runFrequencies } = await import("./tauri");
+    const req = { corpusId: "c1", layer: "word" as const, limit: 12 };
+    await runFrequencies(req);
+    expect(invokeMock).toHaveBeenCalledWith("run_frequencies", { req });
+  });
+
+  it("runTermDistribution forwards the request under `req`", async () => {
+    invokeMock.mockResolvedValue({
+      docCounts: [],
+      dispersion: [],
+      totalHits: 0,
+      elapsedMs: 0,
+    });
+    const { runTermDistribution } = await import("./tauri");
+    const req = { corpusId: "c1", term: "the", layer: "word" as const, buckets: 100 };
+    await runTermDistribution(req);
+    expect(invokeMock).toHaveBeenCalledWith("run_term_distribution", { req });
+  });
+
+  it("expandContext forwards the request under `req`", async () => {
+    invokeMock.mockResolvedValue({
+      docId: 0,
+      path: "a.txt",
+      before: "",
+      hit: "the",
+      after: "",
+      tokenCount: 10,
+    });
+    const { expandContext } = await import("./tauri");
+    const req = { corpusId: "c1", docId: 0, position: 5, context: 45 };
+    await expandContext(req);
+    expect(invokeMock).toHaveBeenCalledWith("expand_context", { req });
+  });
+
+  it("isFixtureCorpus recognises baked-in demo corpora", async () => {
+    const { isFixtureCorpus } = await import("./tauri");
+    expect(isFixtureCorpus("does-not-exist")).toBe(false);
+    expect(isFixtureCorpus("gut-en")).toBe(true);
+  });
+
   it("inTauri detects the runtime marker", async () => {
     const { inTauri } = await import("./tauri");
     expect(inTauri()).toBe(false);

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -3,13 +3,13 @@
 // are fleshed out. UI code reaches through these fns so swapping fixture
 // data for real IPC is a single-file change.
 
+import { CORPORA } from "@/data";
 import type {
   BuildProgress,
   BuildRequest,
   Collocate,
   CorpusMeta,
   KwicRequest,
-  KwicResult,
   QueryLayer,
 } from "@/types";
 
@@ -31,6 +31,86 @@ export interface CollocatesResult {
   windowTokens: number;
 }
 
+/** Raw KWIC hit as returned by the backend — distinct from the UI's
+ *  `KwicHit` (numeric doc id, carries `path` + `hitPosition`). The App
+ *  adapts these into the UI shape. */
+export interface KwicHitRaw {
+  docId: number;
+  path: string;
+  hitPosition: number;
+  left: string;
+  hit: string;
+  right: string;
+}
+
+export interface KwicResultRaw {
+  hits: KwicHitRaw[];
+  elapsedMs: number;
+  truncated: boolean;
+}
+
+export interface DocumentInfo {
+  docId: number;
+  path: string;
+  tokenCount: number;
+}
+
+export interface FrequenciesRequest {
+  corpusId: string;
+  layer: QueryLayer;
+  limit: number;
+}
+
+export interface FreqResultRow {
+  term: string;
+  count: number;
+  pct: number;
+}
+
+export interface FrequenciesResult {
+  rows: FreqResultRow[];
+  totalTokens: number;
+  elapsedMs: number;
+}
+
+export interface TermDistRequest {
+  corpusId: string;
+  term: string;
+  layer: QueryLayer;
+  buckets: number;
+}
+
+export interface DocTermCount {
+  docId: number;
+  path: string;
+  hits: number;
+  tokenCount: number;
+}
+
+export interface TermDistResult {
+  docCounts: DocTermCount[];
+  /** Per-bucket occurrence counts over the corpus position axis. */
+  dispersion: number[];
+  totalHits: number;
+  elapsedMs: number;
+}
+
+export interface ExpandRequest {
+  corpusId: string;
+  docId: number;
+  position: number;
+  context: number;
+}
+
+export interface ExpandedContext {
+  docId: number;
+  path: string;
+  before: string;
+  hit: string;
+  after: string;
+  tokenCount: number;
+}
+
 // Lazy import so calls outside a Tauri runtime (e.g. Storybook) don't crash.
 async function invokeSafe<T>(command: string, args?: Record<string, unknown>): Promise<T> {
   const { invoke } = await import("@tauri-apps/api/core");
@@ -41,8 +121,8 @@ export async function listCorpora(): Promise<CorpusMeta[]> {
   return invokeSafe<CorpusMeta[]>("list_corpora");
 }
 
-export async function runKwic(req: KwicRequest): Promise<KwicResult> {
-  return invokeSafe<KwicResult>("run_kwic", { req });
+export async function runKwic(req: KwicRequest): Promise<KwicResultRaw> {
+  return invokeSafe<KwicResultRaw>("run_kwic", { req });
 }
 
 export async function runCollocates(req: CollocatesRequest): Promise<CollocatesResult> {
@@ -53,10 +133,39 @@ export async function buildIndex(req: BuildRequest): Promise<CorpusMeta> {
   return invokeSafe<CorpusMeta>("build_index", { req });
 }
 
+export async function listDocuments(corpusId: string): Promise<DocumentInfo[]> {
+  return invokeSafe<DocumentInfo[]>("list_documents", { corpusId });
+}
+
+export async function runFrequencies(req: FrequenciesRequest): Promise<FrequenciesResult> {
+  return invokeSafe<FrequenciesResult>("run_frequencies", { req });
+}
+
+export async function runTermDistribution(req: TermDistRequest): Promise<TermDistResult> {
+  return invokeSafe<TermDistResult>("run_term_distribution", { req });
+}
+
+export async function expandContext(req: ExpandRequest): Promise<ExpandedContext> {
+  return invokeSafe<ExpandedContext>("expand_context", { req });
+}
+
 /** True when running inside the Tauri shell. Frontend can fall back to
  *  fixture data when false (Storybook, vite-only dev). */
 export function inTauri(): boolean {
   return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+/** A corpus id that belongs to the baked-in demo fixtures (`@/data`)
+ *  rather than a real, backend-registered corpus. Views use this to
+ *  decide whether to hit IPC or render fixture data. */
+export function isFixtureCorpus(id: string): boolean {
+  return CORPORA.some((c) => c.id === id);
+}
+
+/** Live data is available for a corpus only inside Tauri and only when
+ *  it isn't one of the demo fixtures. */
+export function hasLiveData(id: string): boolean {
+  return inTauri() && !isFixtureCorpus(id);
 }
 
 export type { BuildProgress };

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -39,6 +39,12 @@ export function formatNumber(n: number): string {
   return n.toLocaleString("en-US");
 }
 
+/** Last path segment of a file path (handles both `/` and `\`). */
+export function basename(path: string): string {
+  const parts = path.split(/[/\\]/);
+  return parts[parts.length - 1] || path;
+}
+
 /** Bucket KWIC hits by their doc position into `buckets` density cells. */
 export function makeDensity(hits: { pos: number }[], buckets = 60): number[] {
   const d = new Array(buckets).fill(0) as number[];

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -35,6 +35,10 @@ export interface KwicRequest {
 export interface KwicHit {
   docId: string;
   pos: number;
+  /** Token position of the hit within its document. Carried from the
+   *  backend so the ContextDrawer can re-expand a wider window. Absent
+   *  for fixture hits. */
+  hitPos?: number;
   left: string;
   hit: string;
   right: string;

--- a/crates/corpust-index/src/lib.rs
+++ b/crates/corpust-index/src/lib.rs
@@ -20,6 +20,7 @@ use anyhow::{Context, Result};
 use corpust_annotate::{AnnotatedToken, Annotator};
 use corpust_core::{DocId, Document};
 use rayon::prelude::*;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tantivy::{
     DocAddress, DocSet, Index, IndexReader, ReloadPolicy, TERMINATED, TantivyDocument, Term, doc,
@@ -75,9 +76,42 @@ pub enum QueryLayer {
 pub struct KwicHit {
     pub doc_id: DocId,
     pub path: PathBuf,
+    /// Token position of the hit within its document. Lets callers
+    /// re-expand a wider context later via [`CorpusIndex::context_at`].
+    pub hit_position: usize,
     pub left: String,
     pub hit: String,
     pub right: String,
+}
+
+/// One document's summary, for the corpus document list.
+#[derive(Debug, Clone)]
+pub struct DocumentInfo {
+    pub doc_id: DocId,
+    pub path: PathBuf,
+    pub token_count: usize,
+}
+
+/// Per-document occurrence count of a term.
+#[derive(Debug, Clone)]
+pub struct DocTermCount {
+    pub doc_id: DocId,
+    pub path: PathBuf,
+    pub hits: u64,
+    pub token_count: u64,
+}
+
+/// Corpus-wide distribution of a term: per-document hit counts plus a
+/// dispersion histogram over the whole corpus.
+#[derive(Debug, Clone)]
+pub struct TermDistribution {
+    /// Documents that contain the term, sorted by descending hit count.
+    pub doc_counts: Vec<DocTermCount>,
+    /// Per-bucket occurrence counts over a global position axis
+    /// (documents concatenated in `doc_id` order). Length == requested
+    /// bucket count.
+    pub dispersion: Vec<u32>,
+    pub total_hits: u64,
 }
 
 impl CorpusIndex {
@@ -361,32 +395,17 @@ impl CorpusIndex {
                         break;
                     }
                     let p = pos as usize;
-                    if p >= offsets.len() {
+                    let Some((left, hit, right)) = window(body, &offsets, p, context) else {
                         continue;
-                    }
-
-                    let window_start = p.saturating_sub(context);
-                    let window_end = (p + context + 1).min(offsets.len());
-                    let byte_start = offsets[window_start] as usize;
-                    let byte_end = if window_end < offsets.len() {
-                        offsets[window_end] as usize
-                    } else {
-                        body.len()
                     };
-
-                    let window_text = &body[byte_start..byte_end];
-                    let window_tokens: Vec<&str> = window_text.unicode_words().collect();
-                    let hit_idx = p - window_start;
-                    if hit_idx >= window_tokens.len() {
-                        continue;
-                    }
 
                     hits.push(KwicHit {
                         doc_id,
                         path: PathBuf::from(path),
-                        left: window_tokens[..hit_idx].join(" "),
-                        hit: window_tokens[hit_idx].to_string(),
-                        right: window_tokens[hit_idx + 1..].join(" "),
+                        hit_position: p,
+                        left,
+                        hit,
+                        right,
                     });
                 }
 
@@ -395,6 +414,230 @@ impl CorpusIndex {
         }
 
         Ok(hits)
+    }
+
+    /// Re-extract the concordance window around a known hit position in a
+    /// specific document — used to expand the context shown for a single
+    /// KWIC line after the fact, without re-running the whole query.
+    ///
+    /// Returns `(left, hit, right, token_count)` or `None` if the document
+    /// or position can't be located. Locating the document is a linear
+    /// scan over stored doc ids; document counts are modest so this is
+    /// cheap enough for an on-click expansion.
+    pub fn context_at(
+        &self,
+        doc_id: DocId,
+        position: usize,
+        context: usize,
+    ) -> Result<Option<(String, String, String, usize)>> {
+        let searcher = self.reader.searcher();
+        for (seg_ord, seg_reader) in searcher.segment_readers().iter().enumerate() {
+            for local in seg_reader.doc_ids_alive() {
+                let doc_addr = DocAddress::new(seg_ord as u32, local);
+                let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
+                let stored_id = retrieved
+                    .get_first(self.fields.doc_id)
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(u64::MAX);
+                if stored_id != doc_id {
+                    continue;
+                }
+                let body = retrieved
+                    .get_first(self.fields.body)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                let offsets = retrieved
+                    .get_first(self.fields.token_offsets)
+                    .and_then(|v| v.as_bytes())
+                    .map(bytes_to_offsets)
+                    .unwrap_or_default();
+                let token_count = offsets.len();
+                return Ok(window(body, &offsets, position, context)
+                    .map(|(l, h, r)| (l, h, r, token_count)));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Enumerate every (alive) document with its path and token count.
+    /// Sorted by `doc_id`.
+    pub fn list_documents(&self) -> Result<Vec<DocumentInfo>> {
+        let searcher = self.reader.searcher();
+        let mut out = Vec::new();
+        for (seg_ord, seg_reader) in searcher.segment_readers().iter().enumerate() {
+            for local in seg_reader.doc_ids_alive() {
+                let doc_addr = DocAddress::new(seg_ord as u32, local);
+                let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
+                let doc_id = retrieved
+                    .get_first(self.fields.doc_id)
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let path = retrieved
+                    .get_first(self.fields.path)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                let token_count = retrieved
+                    .get_first(self.fields.token_offsets)
+                    .and_then(|v| v.as_bytes())
+                    .map(|b| bytes_to_offsets(b).len())
+                    .unwrap_or(0);
+                out.push(DocumentInfo {
+                    doc_id,
+                    path: PathBuf::from(path),
+                    token_count,
+                });
+            }
+        }
+        out.sort_by_key(|d| d.doc_id);
+        Ok(out)
+    }
+
+    /// Corpus-wide top-`limit` term frequencies on `layer`. Returns the
+    /// `(term, count)` rows sorted by descending count, plus the grand
+    /// total of (non-empty) token occurrences in the field — the
+    /// denominator callers use to turn counts into percentages.
+    ///
+    /// NOTE: this is a full term-dictionary scan with one postings read
+    /// per term. Fine at the current scale; for billion-word corpora the
+    /// table should be precomputed at build time instead.
+    pub fn frequencies(
+        &self,
+        layer: QueryLayer,
+        limit: usize,
+    ) -> Result<(Vec<(String, u64)>, u64)> {
+        let searcher = self.reader.searcher();
+        let field = self.layer_field(layer);
+        let mut totals: HashMap<String, u64> = HashMap::new();
+        let mut grand_total: u64 = 0;
+        for seg_reader in searcher.segment_readers() {
+            let inv = seg_reader.inverted_index(field)?;
+            let term_dict = inv.terms();
+            let mut stream = term_dict.stream()?;
+            while stream.advance() {
+                let key = match std::str::from_utf8(stream.key()) {
+                    Ok(k) if !k.is_empty() => k.to_string(),
+                    _ => continue,
+                };
+                let term_info = stream.value().clone();
+                let mut postings =
+                    inv.read_postings_from_terminfo(&term_info, IndexRecordOption::WithFreqs)?;
+                let mut sum: u64 = 0;
+                loop {
+                    let doc = postings.doc();
+                    if doc == TERMINATED {
+                        break;
+                    }
+                    sum += postings.term_freq() as u64;
+                    postings.advance();
+                }
+                grand_total += sum;
+                *totals.entry(key).or_default() += sum;
+            }
+        }
+        let mut rows: Vec<(String, u64)> = totals.into_iter().collect();
+        rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        rows.truncate(limit);
+        Ok((rows, grand_total))
+    }
+
+    /// Per-document hit counts and a corpus-wide dispersion histogram for
+    /// a single term on `layer`, in one pass over the term's postings.
+    ///
+    /// The dispersion axis treats the corpus as one long stream of tokens
+    /// (documents concatenated in `doc_id` order); each occurrence falls
+    /// into one of `buckets` equal-width buckets along that axis.
+    pub fn term_distribution(
+        &self,
+        term: &str,
+        layer: QueryLayer,
+        buckets: usize,
+    ) -> Result<TermDistribution> {
+        let buckets = buckets.max(1);
+        let searcher = self.reader.searcher();
+        let field = self.layer_field(layer);
+        let lookup = match layer {
+            QueryLayer::Word | QueryLayer::Lemma => term.to_lowercase(),
+            QueryLayer::Pos => term.to_string(),
+        };
+        let term_obj = Term::from_field_text(field, &lookup);
+
+        // Global position axis: documents in doc_id order, with cumulative
+        // token offsets. Reuse list_documents for ordering + token counts.
+        let docs = self.list_documents()?;
+        let mut global_start: HashMap<DocId, u64> = HashMap::new();
+        let mut cursor: u64 = 0;
+        for d in &docs {
+            global_start.insert(d.doc_id, cursor);
+            cursor += d.token_count as u64;
+        }
+        let total_tokens = cursor.max(1);
+
+        let mut dispersion = vec![0u32; buckets];
+        let mut doc_hits: HashMap<DocId, u64> = HashMap::new();
+        let mut total_hits: u64 = 0;
+        let mut positions_buf: Vec<u32> = Vec::new();
+
+        for (seg_ord, seg_reader) in searcher.segment_readers().iter().enumerate() {
+            let inv = seg_reader.inverted_index(field)?;
+            let Some(mut postings) =
+                inv.read_postings(&term_obj, IndexRecordOption::WithFreqsAndPositions)?
+            else {
+                continue;
+            };
+            loop {
+                let doc = postings.doc();
+                if doc == TERMINATED {
+                    break;
+                }
+                let doc_addr = DocAddress::new(seg_ord as u32, doc);
+                let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
+                let stored_id = retrieved
+                    .get_first(self.fields.doc_id)
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let freq = postings.term_freq() as u64;
+                *doc_hits.entry(stored_id).or_default() += freq;
+                total_hits += freq;
+
+                let base = *global_start.get(&stored_id).unwrap_or(&0);
+                positions_buf.clear();
+                postings.positions(&mut positions_buf);
+                for &p in &positions_buf {
+                    let global_pos = base + p as u64;
+                    let b = ((global_pos * buckets as u64) / total_tokens) as usize;
+                    dispersion[b.min(buckets - 1)] += 1;
+                }
+                postings.advance();
+            }
+        }
+
+        let mut doc_counts: Vec<DocTermCount> = docs
+            .iter()
+            .filter_map(|d| {
+                let hits = *doc_hits.get(&d.doc_id).unwrap_or(&0);
+                (hits > 0).then(|| DocTermCount {
+                    doc_id: d.doc_id,
+                    path: d.path.clone(),
+                    hits,
+                    token_count: d.token_count as u64,
+                })
+            })
+            .collect();
+        doc_counts.sort_by(|a, b| b.hits.cmp(&a.hits).then_with(|| a.doc_id.cmp(&b.doc_id)));
+
+        Ok(TermDistribution {
+            doc_counts,
+            dispersion,
+            total_hits,
+        })
+    }
+
+    fn layer_field(&self, layer: QueryLayer) -> Field {
+        match layer {
+            QueryLayer::Word => self.fields.body,
+            QueryLayer::Lemma => self.fields.body_lemma,
+            QueryLayer::Pos => self.fields.body_pos,
+        }
     }
 }
 
@@ -454,6 +697,42 @@ fn register_tokenizer(index: &Index) {
         .filter(LowerCaser)
         .build();
     index.tokenizers().register(TOKENIZER_NAME, analyzer);
+}
+
+/// Extract the concordance window around token position `p`: `context`
+/// tokens of either side, clamped at document edges. Context text is read
+/// from the stored original `body` so the surface form is source-faithful
+/// regardless of which layer the hit was located on. Returns
+/// `(left, hit, right)`, or `None` if `p` is out of range.
+fn window(
+    body: &str,
+    offsets: &[u32],
+    p: usize,
+    context: usize,
+) -> Option<(String, String, String)> {
+    if p >= offsets.len() {
+        return None;
+    }
+    let window_start = p.saturating_sub(context);
+    let window_end = (p + context + 1).min(offsets.len());
+    let byte_start = offsets[window_start] as usize;
+    let byte_end = if window_end < offsets.len() {
+        offsets[window_end] as usize
+    } else {
+        body.len()
+    };
+
+    let window_text = &body[byte_start..byte_end];
+    let window_tokens: Vec<&str> = window_text.unicode_words().collect();
+    let hit_idx = p - window_start;
+    if hit_idx >= window_tokens.len() {
+        return None;
+    }
+    Some((
+        window_tokens[..hit_idx].join(" "),
+        window_tokens[hit_idx].to_string(),
+        window_tokens[hit_idx + 1..].join(" "),
+    ))
 }
 
 fn offsets_to_bytes(offsets: &[u32]) -> Vec<u8> {
@@ -626,6 +905,93 @@ mod tests {
         let no_pos = idx.kwic("NN", QueryLayer::Pos, 1, 10).unwrap();
         assert!(no_pos.is_empty());
 
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    fn two_doc_index() -> (std::path::PathBuf, CorpusIndex) {
+        let tmp = tempdir();
+        let idx = CorpusIndex::create(&tmp).unwrap();
+        idx.add_documents(
+            [
+                Document {
+                    id: 0,
+                    path: PathBuf::from("a.txt"),
+                    text: "the cat sat on the mat".to_string(),
+                },
+                Document {
+                    id: 1,
+                    path: PathBuf::from("b.txt"),
+                    text: "the dog and the cat".to_string(),
+                },
+            ],
+            None,
+        )
+        .unwrap();
+        (tmp, idx)
+    }
+
+    #[test]
+    fn list_documents_reports_paths_and_token_counts() {
+        let (tmp, idx) = two_doc_index();
+        let docs = idx.list_documents().unwrap();
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].doc_id, 0);
+        assert_eq!(docs[0].path, PathBuf::from("a.txt"));
+        assert_eq!(docs[0].token_count, 6); // the cat sat on the mat
+        assert_eq!(docs[1].doc_id, 1);
+        assert_eq!(docs[1].token_count, 5); // the dog and the cat
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn frequencies_ranks_terms_by_total_count() {
+        let (tmp, idx) = two_doc_index();
+        let (rows, total) = idx.frequencies(QueryLayer::Word, 10).unwrap();
+        // 11 tokens across both docs; "the" appears 4 times.
+        assert_eq!(total, 11);
+        assert_eq!(rows[0], ("the".to_string(), 4));
+        // "cat" appears twice; everything else once.
+        let cat = rows.iter().find(|(t, _)| t == "cat").unwrap();
+        assert_eq!(cat.1, 2);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn context_at_reexpands_window() {
+        let (tmp, idx) = two_doc_index();
+        // Locate a hit first, then re-expand it wider.
+        let hits = idx.kwic("sat", QueryLayer::Word, 1, 10).unwrap();
+        assert_eq!(hits.len(), 1);
+        let h = &hits[0];
+        assert_eq!(h.left, "cat");
+        assert_eq!(h.right, "on");
+
+        let (left, hit, right, tokens) = idx
+            .context_at(h.doc_id, h.hit_position, 10)
+            .unwrap()
+            .unwrap();
+        assert_eq!(hit, "sat");
+        assert_eq!(left, "the cat");
+        assert_eq!(right, "on the mat");
+        assert_eq!(tokens, 6);
+
+        // Unknown doc id yields None.
+        assert!(idx.context_at(999, 0, 3).unwrap().is_none());
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn term_distribution_counts_per_doc_and_buckets() {
+        let (tmp, idx) = two_doc_index();
+        let dist = idx.term_distribution("the", QueryLayer::Word, 4).unwrap();
+        assert_eq!(dist.total_hits, 4);
+        // Both docs contain "the".
+        assert_eq!(dist.doc_counts.len(), 2);
+        let total_in_docs: u64 = dist.doc_counts.iter().map(|d| d.hits).sum();
+        assert_eq!(total_in_docs, 4);
+        // Bucket counts sum to the total number of occurrences.
+        assert_eq!(dist.dispersion.iter().map(|&c| c as u64).sum::<u64>(), 4);
+        assert_eq!(dist.dispersion.len(), 4);
         let _ = std::fs::remove_dir_all(&tmp);
     }
 


### PR DESCRIPTION
## What

The CLI and tagger were end-to-end complete, but the desktop app — the headline deliverable — still rendered fabricated fixtures on three surfaces with no backend behind them. This wires all three to real Tauri commands, keeping the fixtures only as the non-Tauri / browser-preview fallback.

- **ContextDrawer** — clicking a concordance line now expands the *actual* surrounding text via `expand_context`, not the hardcoded `EXPANDED` fixture.
- **CorpusDetail** — the document table lists real files + token counts via `list_documents` (author/year/title columns dropped; not in the index — see #17).
- **FrequencyView** — word/POS tables, per-doc hit counts, and the dispersion strip all reflect the queried term via `run_frequencies` + `run_term_distribution`; toggling word/POS refetches.

## Backend (`corpust-index`)

- Extracted a shared `window()` helper from the kwic loop.
- Added `hit_position` to `KwicHit`, plus `context_at`, `list_documents`, `frequencies`, and `term_distribution` (with `DocumentInfo` / `DocTermCount` / `TermDistribution`), each unit-tested.

## Tauri + frontend

- Registered `list_documents`, `run_frequencies`, `run_term_distribution`, `expand_context` with camelCase DTOs; carry `hitPosition` through KWIC hits.
- Typed IPC wrappers + `isFixtureCorpus` helper; each view fetches its own data via `useEffect` with a fixture fallback.

## Verification

`cargo test` / `clippy` / `fmt` and `npm build` / `test` green. All four methods exercised against a real 546-doc / 95.6M-token CLI-built corpus.

## Follow-ups

- Unblocks #6 (UI polish was gated on real data-driven charts).
- #16 — precompute frequency tables at build time if the full term-dictionary scan bites on large corpora.
- #17 — index author/year/title for richer CorpusDetail columns.