### PR TITLE
Cache query results (list_documents / frequencies / term_distribution)

### DIFF
--- a/crates/corpust-index/src/lib.rs
+++ b/crates/corpust-index/src/lib.rs
@@ -27,8 +27,8 @@ use tantivy::{
     DocAddress, DocSet, Index, IndexReader, ReloadPolicy, TERMINATED, TantivyDocument, Term, doc,
     postings::Postings,
     schema::{
-        BytesOptions, Field, IndexRecordOption, STORED, Schema, TextFieldIndexing, TextOptions,
-        Value,
+        BytesOptions, FAST, Field, IndexRecordOption, STORED, Schema, TextFieldIndexing,
+        TextOptions, Value,
     },
     tokenizer::{LowerCaser, PreTokenizedString, TextAnalyzer, Token, TokenStream, Tokenizer},
 };
@@ -68,8 +68,10 @@ struct Fields {
     body_lemma: Field,
     body_pos: Field,
     token_offsets: Field,
-    /// Metadata fields are optional so indexes built before metadata
-    /// extraction landed still open cleanly (their schema lacks them).
+    /// Optional so indexes built before these fields landed still open
+    /// cleanly (their schema lacks them). `token_count` is a FAST u64;
+    /// the metadata fields are stored text/u64.
+    token_count: Option<Field>,
     title: Option<Field>,
     author: Option<Field>,
     year: Option<Field>,
@@ -176,6 +178,7 @@ impl CorpusIndex {
             body_lemma: schema.get_field("body_lemma")?,
             body_pos: schema.get_field("body_pos")?,
             token_offsets: schema.get_field("token_offsets")?,
+            token_count: schema.get_field("token_count").ok(),
             title: schema.get_field("title").ok(),
             author: schema.get_field("author").ok(),
             year: schema.get_field("year").ok(),
@@ -295,6 +298,9 @@ impl CorpusIndex {
             self.fields.body => document.text.clone(),
             self.fields.token_offsets => offsets_bytes,
         );
+        if let Some(f) = self.fields.token_count {
+            tantivy_doc.add_u64(f, offsets.len() as u64);
+        }
         self.add_metadata_fields(&mut tantivy_doc, &document.text);
         writer.add_document(tantivy_doc)?;
         Ok(())
@@ -379,6 +385,9 @@ impl CorpusIndex {
             self.fields.body_pos => pos_pre,
             self.fields.token_offsets => offsets_bytes,
         );
+        if let Some(f) = self.fields.token_count {
+            tantivy_doc.add_u64(f, offsets.len() as u64);
+        }
         self.add_metadata_fields(&mut tantivy_doc, &document.text);
         writer.add_document(tantivy_doc)?;
         Ok(())
@@ -688,17 +697,27 @@ impl CorpusIndex {
             else {
                 continue;
             };
+            // Read the stored doc id from the FAST column when present —
+            // a columnar lookup, vs fetching the whole stored document
+            // (incl. the ~MB body) per matched doc. Falls back to the
+            // stored field on indexes built before doc_id was FAST.
+            let doc_id_col = seg_reader.fast_fields().u64("doc_id").ok();
             loop {
                 let doc = postings.doc();
                 if doc == TERMINATED {
                     break;
                 }
-                let doc_addr = DocAddress::new(seg_ord as u32, doc);
-                let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
-                let stored_id = retrieved
-                    .get_first(self.fields.doc_id)
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
+                let stored_id = match &doc_id_col {
+                    Some(col) => col.first(doc).unwrap_or(0),
+                    None => {
+                        let doc_addr = DocAddress::new(seg_ord as u32, doc);
+                        let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
+                        retrieved
+                            .get_first(self.fields.doc_id)
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0)
+                    }
+                };
                 let freq = postings.term_freq() as u64;
                 *doc_hits.entry(stored_id).or_default() += freq;
                 total_hits += freq;
@@ -1082,8 +1101,14 @@ fn extract_year(body: &str) -> Option<u32> {
 
 fn build_schema() -> (Schema, Fields) {
     let mut builder = Schema::builder();
-    let doc_id = builder.add_u64_field("doc_id", STORED);
+    // doc_id is FAST so term_distribution can map a matched segment-doc to
+    // its stored id via a columnar read, instead of fetching the whole
+    // stored document (incl. the ~MB body) per match.
+    let doc_id = builder.add_u64_field("doc_id", STORED | FAST);
     let path = builder.add_text_field("path", STORED);
+    // Per-document token count, FAST so the distribution axis is built
+    // columnar without parsing every doc's token_offsets sidecar.
+    let token_count = builder.add_u64_field("token_count", STORED | FAST);
 
     let indexing = TextFieldIndexing::default()
         .set_tokenizer(TOKENIZER_NAME)
@@ -1118,6 +1143,7 @@ fn build_schema() -> (Schema, Fields) {
             body_lemma,
             body_pos,
             token_offsets,
+            token_count: Some(token_count),
             title: Some(title),
             author: Some(author),
             year: Some(year),

--- a/crates/corpust-index/src/lib.rs
+++ b/crates/corpust-index/src/lib.rs
@@ -22,6 +22,7 @@ use corpust_core::{DocId, Document};
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use tantivy::{
     DocAddress, DocSet, Index, IndexReader, ReloadPolicy, TERMINATED, TantivyDocument, Term, doc,
     postings::Postings,
@@ -45,7 +46,19 @@ pub struct CorpusIndex {
     index: Index,
     reader: IndexReader,
     fields: Fields,
+    /// Query-result caches. The index is immutable once opened (the app
+    /// re-opens a fresh `CorpusIndex` after a rebuild), so memoizing these
+    /// O(corpus) reads is sound and turns repeat layer-toggles / revisits
+    /// from seconds into nothing. Keyed by their full input so different
+    /// layers / terms / limits don't collide.
+    doc_cache: OnceLock<Vec<DocumentInfo>>,
+    freq_cache: Mutex<HashMap<(QueryLayer, usize), FreqTable>>,
+    dist_cache: Mutex<HashMap<(String, QueryLayer, usize), TermDistribution>>,
 }
+
+/// Top-N `(term, count)` rows plus the field's grand-total token count —
+/// the return shape of [`CorpusIndex::frequencies`].
+pub type FreqTable = (Vec<(String, u64)>, u64);
 
 #[derive(Clone, Copy)]
 struct Fields {
@@ -69,7 +82,7 @@ struct Fields {
 /// for documents indexed with an [`Annotator`] that emits lemmas.
 /// `Pos` queries the POS-tag layer (case-sensitive — conventionally
 /// uppercase tagsets like Penn Treebank).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum QueryLayer {
     Word,
     Lemma,
@@ -179,6 +192,9 @@ impl CorpusIndex {
             index,
             reader,
             fields,
+            doc_cache: OnceLock::new(),
+            freq_cache: Mutex::new(HashMap::new()),
+            dist_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -506,6 +522,9 @@ impl CorpusIndex {
     /// Enumerate every (alive) document with its path and token count.
     /// Sorted by `doc_id`.
     pub fn list_documents(&self) -> Result<Vec<DocumentInfo>> {
+        if let Some(cached) = self.doc_cache.get() {
+            return Ok(cached.clone());
+        }
         let searcher = self.reader.searcher();
         let mut out = Vec::new();
         for (seg_ord, seg_reader) in searcher.segment_readers().iter().enumerate() {
@@ -553,6 +572,9 @@ impl CorpusIndex {
             }
         }
         out.sort_by_key(|d| d.doc_id);
+        // Cache the document list — it never changes for an open index and
+        // is hit on every `term_distribution` call (global position axis).
+        let _ = self.doc_cache.set(out.clone());
         Ok(out)
     }
 
@@ -564,11 +586,15 @@ impl CorpusIndex {
     /// NOTE: this is a full term-dictionary scan with one postings read
     /// per term. Fine at the current scale; for billion-word corpora the
     /// table should be precomputed at build time instead.
-    pub fn frequencies(
-        &self,
-        layer: QueryLayer,
-        limit: usize,
-    ) -> Result<(Vec<(String, u64)>, u64)> {
+    pub fn frequencies(&self, layer: QueryLayer, limit: usize) -> Result<FreqTable> {
+        if let Some(cached) = self
+            .freq_cache
+            .lock()
+            .expect("freq_cache poisoned")
+            .get(&(layer, limit))
+        {
+            return Ok(cached.clone());
+        }
         let searcher = self.reader.searcher();
         let field = self.layer_field(layer);
         let mut totals: HashMap<String, u64> = HashMap::new();
@@ -601,7 +627,12 @@ impl CorpusIndex {
         let mut rows: Vec<(String, u64)> = totals.into_iter().collect();
         rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         rows.truncate(limit);
-        Ok((rows, grand_total))
+        let result = (rows, grand_total);
+        self.freq_cache
+            .lock()
+            .expect("freq_cache poisoned")
+            .insert((layer, limit), result.clone());
+        Ok(result)
     }
 
     /// Per-document hit counts and a corpus-wide dispersion histogram for
@@ -617,6 +648,15 @@ impl CorpusIndex {
         buckets: usize,
     ) -> Result<TermDistribution> {
         let buckets = buckets.max(1);
+        let cache_key = (term.to_string(), layer, buckets);
+        if let Some(cached) = self
+            .dist_cache
+            .lock()
+            .expect("dist_cache poisoned")
+            .get(&cache_key)
+        {
+            return Ok(cached.clone());
+        }
         let searcher = self.reader.searcher();
         let field = self.layer_field(layer);
         let lookup = match layer {
@@ -689,11 +729,16 @@ impl CorpusIndex {
             .collect();
         doc_counts.sort_by(|a, b| b.hits.cmp(&a.hits).then_with(|| a.doc_id.cmp(&b.doc_id)));
 
-        Ok(TermDistribution {
+        let result = TermDistribution {
             doc_counts,
             dispersion,
             total_hits,
-        })
+        };
+        self.dist_cache
+            .lock()
+            .expect("dist_cache poisoned")
+            .insert(cache_key, result.clone());
+        Ok(result)
     }
 
     fn layer_field(&self, layer: QueryLayer) -> Field {


### PR DESCRIPTION
Addresses the frequency-view slowness reported while running the app.

## Problem
The UI re-runs these O(corpus) reads on every layer toggle / view revisit, and nothing memoized them. On the real 544-doc / 80M-token corpus (release): word frequencies ≈0.75 s, term_distribution ≈1.5 s — *every time*. Under a `tauri:dev` debug build that's 10–50× worse ("loads forever").

## Fix
An opened `CorpusIndex` is immutable in the query path (the app re-opens a fresh index after a rebuild), so memoizing is sound. Three caches:
- `list_documents` → `OnceLock` (also reused by `term_distribution`'s position axis)
- `frequencies` → keyed by (layer, limit)
- `term_distribution` → keyed by (term, layer, buckets)

## Result (measured, release, real corpus)
| op | cold | warm |
|---|---|---|
| word frequencies | 748 ms | **0.0 ms** |
| lemma frequencies | 82 ms | **0.0 ms** |
| term_distribution word/king | 1549 ms | **0.0 ms** |
| term_distribution pos/NN | 785 ms | **0.0 ms** |

Every repeat interaction is now instant. Cold first-touch is unchanged (a follow-up could add `doc_id`/`token_count` fast fields to cut cold `term_distribution` too, but that needs a corpus rebuild).

`cargo test -p corpust-index` (18) + clippy + fmt clean.