### PR TITLE
Precompute per-layer frequency tables at build time

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -13,7 +13,7 @@ use crate::{
     TermDistRequest, TermDistResult,
 };
 use corpust_annotate::{Annotator, treetagger::TreeTagger};
-use corpust_index::{CorpusIndex, DEFAULT_CONTEXT};
+use corpust_index::{CorpusIndex, DEFAULT_CONTEXT, QueryLayer};
 use corpust_io::paths;
 use corpust_query::{KwicRequest as CoreKwicRequest, kwic as run_core_kwic};
 use corpust_tagger::Tagger as RustTagger;
@@ -307,12 +307,19 @@ pub fn run_frequencies(
     req: FrequenciesRequest,
 ) -> Result<FrequenciesResult, String> {
     let limit = req.limit.clamp(1, 1000);
+    let layer: QueryLayer = req.layer.into();
     let t0 = Instant::now();
-    let (rows, total_tokens) = with_corpus(&state, &req.corpus_id, |index| {
-        index
-            .frequencies(req.layer.into(), limit)
-            .map_err(|e| format!("frequencies failed: {e:#}"))
-    })?;
+    // Prefer the precomputed sidecar written at build time; fall back to
+    // a live term-dictionary scan for corpora built before it existed
+    // (or if the request asks for more rows than were precomputed).
+    let (rows, total_tokens) = match load_precomputed_frequencies(&req.corpus_id, layer, limit) {
+        Some(table) => table,
+        None => with_corpus(&state, &req.corpus_id, |index| {
+            index
+                .frequencies(layer, limit)
+                .map_err(|e| format!("frequencies failed: {e:#}"))
+        })?,
+    };
     let denom = total_tokens.max(1) as f64;
     let rows = rows
         .into_iter()
@@ -592,6 +599,11 @@ fn build_index_inner(
     write_metadata_file(&corpus_dir.join("metadata.json"), &meta)
         .map_err(|e| format!("writing metadata: {e:#}"))?;
 
+    // Precompute per-layer frequency tables so FrequencyView serves from
+    // a sidecar instead of re-scanning the term dictionary on every open.
+    // Best-effort — the query path falls back to a live scan if absent.
+    write_frequency_sidecar(&index, &corpus_dir);
+
     emit_progress(
         app,
         started,
@@ -638,6 +650,67 @@ where
         .expect("corpus registry poisoned")
         .insert(id.to_owned(), OpenedCorpus { index, meta });
     result
+}
+
+/// Precompute and persist the per-layer frequency tables next to the
+/// index. Best-effort: any failure only forfeits the speedup (queries
+/// fall back to a live scan), so it never aborts a build — it logs.
+fn write_frequency_sidecar(index: &CorpusIndex, corpus_dir: &Path) {
+    use corpust_io::freq::{FreqTables, LayerFreq, PRECOMPUTE_LIMIT, write_freq_file};
+    let af = match index.all_frequencies(PRECOMPUTE_LIMIT) {
+        Ok(af) => af,
+        Err(e) => {
+            eprintln!("warning: couldn't precompute frequencies: {e:#}");
+            return;
+        }
+    };
+    let tables = FreqTables {
+        limit: PRECOMPUTE_LIMIT,
+        word: LayerFreq::from_table(af.word),
+        lemma: LayerFreq::from_table(af.lemma),
+        pos: LayerFreq::from_table(af.pos),
+    };
+    let path = corpus_dir.join("frequencies.json");
+    if let Err(e) = write_freq_file(&path, &tables) {
+        eprintln!("warning: couldn't write {}: {e:#}", path.display());
+    }
+}
+
+/// Serve a frequency request from the precomputed sidecar, or `None` to
+/// signal the caller should fall back to a live scan. Returns `None`
+/// when the sidecar is absent/unreadable or was computed with fewer rows
+/// than `limit` asks for.
+fn load_precomputed_frequencies(
+    slug: &str,
+    layer: QueryLayer,
+    limit: usize,
+) -> Option<(Vec<(String, u64)>, u64)> {
+    let path = paths::freq_path(slug).ok()?;
+    load_precomputed_from(&path, layer, limit)
+}
+
+/// Path-based core of [`load_precomputed_frequencies`], split out so it
+/// can be tested without touching the global `CORPUST_DATA_ROOT`.
+fn load_precomputed_from(
+    path: &Path,
+    layer: QueryLayer,
+    limit: usize,
+) -> Option<(Vec<(String, u64)>, u64)> {
+    if !path.exists() {
+        return None;
+    }
+    let tables = corpust_io::freq::read_freq_file(path).ok()?;
+    if tables.limit < limit {
+        return None;
+    }
+    let layer_freq = match layer {
+        QueryLayer::Word => tables.word,
+        QueryLayer::Lemma => tables.lemma,
+        QueryLayer::Pos => tables.pos,
+    };
+    let mut rows = layer_freq.rows;
+    rows.truncate(limit);
+    Some((rows, layer_freq.total))
 }
 
 /// Open an existing corpus from disk by slug. Returns the tantivy
@@ -853,5 +926,66 @@ mod tests {
                 .contains("unsupported metadata schema version"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn precomputed_frequencies_serve_truncate_and_fallback() {
+        use corpust_io::freq::{FreqTables, LayerFreq, PRECOMPUTE_LIMIT, write_freq_file};
+
+        let path = tmp_file("freq-serve");
+        let tables = FreqTables {
+            limit: PRECOMPUTE_LIMIT,
+            word: LayerFreq {
+                rows: vec![("the".into(), 10), ("cat".into(), 5), ("dog".into(), 3)],
+                total: 18,
+            },
+            lemma: LayerFreq::default(),
+            pos: LayerFreq {
+                rows: vec![("NN".into(), 8)],
+                total: 18,
+            },
+        };
+        write_freq_file(&path, &tables).unwrap();
+
+        // Serves the word layer, truncated to the requested limit.
+        let (rows, total) = load_precomputed_from(&path, QueryLayer::Word, 2).unwrap();
+        assert_eq!(rows, vec![("the".into(), 10), ("cat".into(), 5)]);
+        assert_eq!(total, 18);
+
+        // POS layer comes through; total is the field grand total.
+        let (pos_rows, _) = load_precomputed_from(&path, QueryLayer::Pos, 10).unwrap();
+        assert_eq!(pos_rows, vec![("NN".into(), 8)]);
+
+        // Lemma layer is empty for an unannotated corpus — served, not a fallback.
+        let (lemma_rows, _) = load_precomputed_from(&path, QueryLayer::Lemma, 10).unwrap();
+        assert!(lemma_rows.is_empty());
+
+        std::fs::remove_file(&path).ok();
+
+        // Missing sidecar → None, signalling a live-scan fallback.
+        assert!(load_precomputed_from(&path, QueryLayer::Word, 2).is_none());
+    }
+
+    #[test]
+    fn precomputed_frequencies_falls_back_when_limit_exceeds_precompute() {
+        use corpust_io::freq::{FreqTables, LayerFreq, write_freq_file};
+
+        let path = tmp_file("freq-toosmall");
+        let tables = FreqTables {
+            limit: 2, // precomputed only top-2
+            word: LayerFreq {
+                rows: vec![("the".into(), 10), ("cat".into(), 5)],
+                total: 18,
+            },
+            ..Default::default()
+        };
+        write_freq_file(&path, &tables).unwrap();
+
+        // Asking for more than was precomputed forces a fallback.
+        assert!(load_precomputed_from(&path, QueryLayer::Word, 5).is_none());
+        // Within the precomputed depth it still serves.
+        assert!(load_precomputed_from(&path, QueryLayer::Word, 2).is_some());
+
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/crates/corpust-cli/src/main.rs
+++ b/crates/corpust-cli/src/main.rs
@@ -321,6 +321,12 @@ fn run_index(
         eprintln!("warning: couldn't write {}: {e:#}", metadata_path.display());
     }
 
+    // Precompute the per-layer frequency tables once so the UI's
+    // FrequencyView doesn't re-scan the term dictionary on every open.
+    // Best-effort: a failure here only forfeits the speedup (the query
+    // path falls back to a live scan), so it must not fail the build.
+    write_frequency_sidecar(&index, &corpus_dir);
+
     println!(
         "indexed {doc_count} doc(s) ({byte_count} bytes) in {:.2?} (read {:.2?} + index {:.2?})",
         t0.elapsed(),
@@ -330,6 +336,30 @@ fn run_index(
     println!("index written to {}", out.display());
     println!("metadata written to {}", metadata_path.display());
     Ok(())
+}
+
+/// Precompute and persist the per-layer frequency tables next to the
+/// index. Best-effort — logs a warning and returns on any failure so a
+/// flaky sidecar never fails an otherwise-good build.
+fn write_frequency_sidecar(index: &CorpusIndex, corpus_dir: &std::path::Path) {
+    use corpust_io::freq::{FreqTables, LayerFreq, PRECOMPUTE_LIMIT, write_freq_file};
+    let af = match index.all_frequencies(PRECOMPUTE_LIMIT) {
+        Ok(af) => af,
+        Err(e) => {
+            eprintln!("warning: couldn't precompute frequencies: {e:#}");
+            return;
+        }
+    };
+    let tables = FreqTables {
+        limit: PRECOMPUTE_LIMIT,
+        word: LayerFreq::from_table(af.word),
+        lemma: LayerFreq::from_table(af.lemma),
+        pos: LayerFreq::from_table(af.pos),
+    };
+    let path = corpus_dir.join("frequencies.json");
+    if let Err(e) = write_freq_file(&path, &tables) {
+        eprintln!("warning: couldn't write {}: {e:#}", path.display());
+    }
 }
 
 fn build_tagger(

--- a/crates/corpust-cli/tests/cli.rs
+++ b/crates/corpust-cli/tests/cli.rs
@@ -67,6 +67,17 @@ fn index_then_kwic_word_layer() {
     assert!(meta_raw.contains("\"schemaVersion\""));
     assert!(meta_raw.contains("\"docCount\": 2"));
 
+    // Precomputed frequency sidecar should land next to the index too,
+    // with "the" as the top word-layer term across both docs.
+    let freq_path = out.parent().unwrap().join("frequencies.json");
+    assert!(
+        freq_path.exists(),
+        "expected frequencies.json at {freq_path:?}"
+    );
+    let freq_raw = fs::read_to_string(&freq_path).unwrap();
+    assert!(freq_raw.contains("\"schemaVersion\""));
+    assert!(freq_raw.contains("\"the\""));
+
     corpust()
         .args(["kwic"])
         .args(["--index"])

--- a/crates/corpust-index/src/lib.rs
+++ b/crates/corpust-index/src/lib.rs
@@ -60,6 +60,16 @@ pub struct CorpusIndex {
 /// the return shape of [`CorpusIndex::frequencies`].
 pub type FreqTable = (Vec<(String, u64)>, u64);
 
+/// The [`FreqTable`] for each [`QueryLayer`], produced in one shot by
+/// [`CorpusIndex::all_frequencies`]. Build paths persist this so the
+/// FrequencyView doesn't re-scan the term dictionary on every open.
+#[derive(Debug, Clone)]
+pub struct AllFrequencies {
+    pub word: FreqTable,
+    pub lemma: FreqTable,
+    pub pos: FreqTable,
+}
+
 #[derive(Clone, Copy)]
 struct Fields {
     doc_id: Field,
@@ -642,6 +652,18 @@ impl CorpusIndex {
             .expect("freq_cache poisoned")
             .insert((layer, limit), result.clone());
         Ok(result)
+    }
+
+    /// Compute the top-`limit` [`FreqTable`] for all three layers in one
+    /// call. Build paths use this to precompute and persist the tables
+    /// (see the NOTE on [`Self::frequencies`]); `Lemma` / `Pos` come back
+    /// empty for corpora indexed without annotation.
+    pub fn all_frequencies(&self, limit: usize) -> Result<AllFrequencies> {
+        Ok(AllFrequencies {
+            word: self.frequencies(QueryLayer::Word, limit)?,
+            lemma: self.frequencies(QueryLayer::Lemma, limit)?,
+            pos: self.frequencies(QueryLayer::Pos, limit)?,
+        })
     }
 
     /// Per-document hit counts and a corpus-wide dispersion histogram for

--- a/crates/corpust-io/src/freq.rs
+++ b/crates/corpust-io/src/freq.rs
@@ -1,0 +1,144 @@
+//! Precomputed corpus-wide frequency tables, persisted next to the
+//! index as `frequencies.json`.
+//!
+//! `CorpusIndex::frequencies` does a full term-dictionary scan with one
+//! postings read per term. That's fine at the current scale but grows
+//! with the corpus and is recomputed every time the FrequencyView opens.
+//! To keep large corpora snappy, the build step precomputes the per-layer
+//! top-N (plus the field's grand total) once and writes it here; the
+//! query path serves from this sidecar and falls back to the live scan
+//! only when the file is absent (e.g. a corpus built before this landed).
+//!
+//! The envelope carries a `schema_version` mirroring the metadata
+//! sidecar, so the format can be migrated rather than silently
+//! misread.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// How many top terms the build step precomputes per layer. Chosen to
+/// cover the FrequencyView's request clamp (the Tauri command caps
+/// `limit` at 1000), so the sidecar always satisfies a UI request
+/// without falling back to a live scan.
+pub const PRECOMPUTE_LIMIT: usize = 1000;
+
+/// One layer's precomputed table: the top terms (descending by count)
+/// and the field's grand-total occurrence count — the denominator the
+/// UI uses to turn counts into percentages.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LayerFreq {
+    pub rows: Vec<(String, u64)>,
+    pub total: u64,
+}
+
+impl LayerFreq {
+    /// Build from the `(rows, total)` tuple `CorpusIndex::frequencies`
+    /// returns.
+    pub fn from_table(table: (Vec<(String, u64)>, u64)) -> Self {
+        let (rows, total) = table;
+        Self { rows, total }
+    }
+}
+
+/// Precomputed frequency tables for every query layer.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FreqTables {
+    /// The `limit` the tables were computed with — i.e. each layer holds
+    /// at most this many rows. A reader can only serve requests for up to
+    /// this many terms; larger requests must fall back to a live scan.
+    pub limit: usize,
+    pub word: LayerFreq,
+    pub lemma: LayerFreq,
+    pub pos: LayerFreq,
+}
+
+/// Versioned wrapper around [`FreqTables`]. On-disk shape is
+/// `{ "schemaVersion": 1, "tables": { ... } }`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FreqTablesEnvelope {
+    pub schema_version: u32,
+    pub tables: FreqTables,
+}
+
+impl FreqTablesEnvelope {
+    pub const CURRENT_VERSION: u32 = 1;
+
+    pub fn wrap(tables: FreqTables) -> Self {
+        Self {
+            schema_version: Self::CURRENT_VERSION,
+            tables,
+        }
+    }
+}
+
+/// Serialize the envelope as pretty JSON and write to `path`. Called by
+/// both the CLI `index` subcommand and the Tauri build command after the
+/// index commits.
+pub fn write_freq_file(path: &Path, tables: &FreqTables) -> Result<()> {
+    let envelope = FreqTablesEnvelope::wrap(tables.clone());
+    let json = serde_json::to_vec_pretty(&envelope)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+/// Read and unwrap the frequency sidecar at `path`. Returns the inner
+/// [`FreqTables`]; the caller decides whether a missing file or a
+/// too-small `limit` warrants a live-scan fallback.
+pub fn read_freq_file(path: &Path) -> Result<FreqTables> {
+    let bytes = std::fs::read(path)?;
+    let envelope: FreqTablesEnvelope = serde_json::from_slice(&bytes)?;
+    Ok(envelope.tables)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_read_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("frequencies.json");
+        let tables = FreqTables {
+            limit: PRECOMPUTE_LIMIT,
+            word: LayerFreq {
+                rows: vec![("the".into(), 42), ("and".into(), 17)],
+                total: 100,
+            },
+            lemma: LayerFreq::default(),
+            pos: LayerFreq {
+                rows: vec![("NN".into(), 30)],
+                total: 100,
+            },
+        };
+
+        write_freq_file(&path, &tables).unwrap();
+        let back = read_freq_file(&path).unwrap();
+
+        assert_eq!(back.limit, PRECOMPUTE_LIMIT);
+        assert_eq!(back.word.rows, vec![("the".into(), 42), ("and".into(), 17)]);
+        assert_eq!(back.word.total, 100);
+        assert!(back.lemma.rows.is_empty());
+        assert_eq!(back.pos.rows, vec![("NN".into(), 30)]);
+
+        // camelCase + version contract.
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("\"schemaVersion\""));
+    }
+
+    #[test]
+    fn read_missing_file_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.json");
+        assert!(read_freq_file(&missing).is_err());
+    }
+
+    #[test]
+    fn from_table_splits_tuple() {
+        let lf = LayerFreq::from_table((vec![("x".into(), 5)], 5));
+        assert_eq!(lf.rows, vec![("x".into(), 5)]);
+        assert_eq!(lf.total, 5);
+    }
+}

--- a/crates/corpust-io/src/lib.rs
+++ b/crates/corpust-io/src/lib.rs
@@ -4,6 +4,7 @@
 //! come later — each as a separate reader behind a common trait once we have
 //! enough shape to know what the trait should look like.
 
+pub mod freq;
 pub mod metadata;
 pub mod paths;
 

--- a/crates/corpust-io/src/paths.rs
+++ b/crates/corpust-io/src/paths.rs
@@ -6,8 +6,9 @@
 //! <data_root>/
 //! └── corpora/
 //!     └── <slug>/
-//!         ├── index/        ← tantivy files
-//!         └── metadata.json ← versioned CorpusMeta sidecar
+//!         ├── index/           ← tantivy files
+//!         ├── metadata.json    ← versioned CorpusMeta sidecar
+//!         └── frequencies.json ← versioned precomputed freq tables
 //! ```
 //!
 //! On macOS that's `~/Library/Application Support/corpust/`; on Linux
@@ -61,6 +62,11 @@ pub fn index_path(slug: &str) -> Result<PathBuf> {
 /// Path to the metadata sidecar inside a corpus dir.
 pub fn metadata_path(slug: &str) -> Result<PathBuf> {
     Ok(corpus_dir(slug)?.join("metadata.json"))
+}
+
+/// Path to the precomputed frequency-table sidecar inside a corpus dir.
+pub fn freq_path(slug: &str) -> Result<PathBuf> {
+    Ok(corpus_dir(slug)?.join("frequencies.json"))
 }
 
 /// Turn a human-chosen corpus name into a filesystem-safe slug.
@@ -175,6 +181,10 @@ mod tests {
         assert_eq!(
             metadata_path("foo").unwrap(),
             tmp_root.join("corpora/foo/metadata.json")
+        );
+        assert_eq!(
+            freq_path("foo").unwrap(),
+            tmp_root.join("corpora/foo/frequencies.json")
         );
 
         // Empty CORPUST_DATA_ROOT falls back to the default lookup.


### PR DESCRIPTION
Closes #16.

## What
`CorpusIndex::frequencies` does a full term-dictionary scan (one postings read per term) and recomputes on every FrequencyView open. This precomputes the per-layer top-1000 (+ grand total) once at build time and persists a versioned `frequencies.json` sidecar next to `metadata.json`.

- **corpust-index** — `all_frequencies(limit)` returns the per-layer `FreqTable` in one shot, reusing the existing `frequencies()` scan.
- **corpust-io** — new `freq` module (`FreqTables`/`LayerFreq` versioned envelope + `read`/`write`) and `paths::freq_path`. Separate sidecar so the small `metadata.json` that `list_corpora` reads on every launch stays lean.
- **Build paths** — CLI `run_index` and Tauri `build_index_inner` write the sidecar after commit, best-effort (a failure logs but never fails the build).
- **Serve path** — `run_frequencies` serves from the sidecar (truncated to the request) and **falls back to the live scan** when the sidecar is absent (corpora built before this) or was computed with fewer rows than requested. Top-1000 matches the command's `limit` clamp, so the app always hits the fast path.

## Compatibility
Older corpora without the sidecar keep working unchanged — the serve path just falls back to the live scan, same as today.

## Verification
- `cargo test -p corpust-index -p corpust-io -p corpust-cli` + Tauri backend tests green (sidecar roundtrip, CLI build asserts `frequencies.json` + top term, serve/truncate/fallback unit tests).
- `cargo clippy --workspace --all-targets` + `cargo fmt --check` clean.