### PR TITLE
Real collocation association measures (logDice, MI, z-score)

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -122,119 +122,116 @@ pub fn open_corpus(state: State<'_, AppState>, id: String) -> Result<CorpusMeta,
     Ok(meta)
 }
 
+/// Async so the full-corpus collocation scan runs on a worker thread —
+/// Tauri routes sync `fn` commands onto the main thread, where a scan
+/// over a frequent node ("the" in a 100M-token corpus) would freeze the
+/// window. `spawn_blocking` keeps the index/I-O code synchronous while
+/// the UI stays responsive (the frontend shows a loading state).
 #[tauri::command]
-pub fn run_collocates(
-    state: State<'_, AppState>,
+pub async fn run_collocates(
+    app: AppHandle,
     req: CollocatesRequest,
 ) -> Result<CollocatesResult, String> {
-    // Pull a large KWIC result with enough context to cover both
-    // window sides, then aggregate collocates. Cap hits at 5000 —
-    // enough for meaningful collocations on common terms without
-    // blowing up on "the".
-    const HIT_CAP: usize = 5000;
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        run_collocates_inner(&state, &req)
+    })
+    .await
+    .map_err(|e| format!("collocates task failed to join: {e}"))?
+}
+
+fn run_collocates_inner(
+    state: &State<'_, AppState>,
+    req: &CollocatesRequest,
+) -> Result<CollocatesResult, String> {
+    // Safety ceiling on the positional scan. Set high enough that a full
+    // pass is the norm; only pathologically frequent nodes hit it, and
+    // when they do `truncated` surfaces it rather than silently capping.
+    const MAX_NODE_OCCURRENCES: usize = 1_000_000;
+
     let lw = req.left_window.min(30);
     let rw = req.right_window.min(30);
     if lw == 0 && rw == 0 {
         return Err("collocation window must include at least one side".to_owned());
     }
-    let context = lw.max(rw).max(1);
-    let kreq = CoreKwicRequest::new(&req.term)
-        .layer(req.layer.into())
-        .context(context)
-        .limit(HIT_CAP);
+    let layer: QueryLayer = req.layer.into();
+    let limit = req.limit.clamp(1, 200);
+    let span = (lw + rw) as u64;
     let t0 = Instant::now();
-    let hits = with_corpus(&state, &req.corpus_id, |index| {
-        run_core_kwic(index, kreq).map_err(|e| format!("kwic failed: {e:#}"))
-    })?;
 
-    // Count word occurrences per side, honoring asymmetric L/R
-    // windows. The KWIC call fetched `context` tokens of each side,
-    // so we now trim each side's stream to the requested L or R
-    // window (left: last N tokens; right: first N tokens).
-    use std::collections::HashMap;
-    let mut left_counts: HashMap<String, u32> = HashMap::new();
-    let mut right_counts: HashMap<String, u32> = HashMap::new();
-    let mut window_tokens: u32 = 0;
+    let (collocates, node_freq, window_tokens, truncated) =
+        with_corpus(state, &req.corpus_id, |index| {
+            let scan = index
+                .collocate_counts(&req.term, layer, lw, rw, MAX_NODE_OCCURRENCES)
+                .map_err(|e| format!("collocate scan failed: {e:#}"))?;
 
-    for h in &hits {
-        if lw > 0 {
-            let left_toks: Vec<String> = tokenize_for_collocates(&h.left).collect();
-            let start = left_toks.len().saturating_sub(lw);
-            for w in &left_toks[start..] {
-                *left_counts.entry(w.clone()).or_default() += 1;
-                window_tokens += 1;
-            }
-        }
-        if rw > 0 {
-            for w in tokenize_for_collocates(&h.right).take(rw) {
-                *right_counts.entry(w).or_default() += 1;
-                window_tokens += 1;
-            }
-        }
-    }
+            // Corpus size and collocate marginals are taken on the
+            // surface (word) layer — collocates are surface forms read
+            // from `body`, regardless of which layer the node matched on.
+            let n = index
+                .layer_total_tokens(corpust_index::QueryLayer::Word)
+                .map_err(|e| format!("corpus size lookup failed: {e:#}"))?;
 
-    // Merge sides + rank by total.
-    let mut merged: HashMap<String, (u32, u32)> = HashMap::new();
-    for (w, l) in left_counts {
-        merged.entry(w).or_default().0 = l;
-    }
-    for (w, r) in right_counts {
-        merged.entry(w).or_default().1 = r;
-    }
-    let mut vec: Vec<(String, u32, u32)> =
-        merged.into_iter().map(|(w, (l, r))| (w, l, r)).collect();
-    vec.sort_by(|a, b| (b.1 + b.2).cmp(&(a.1 + a.2)));
-    vec.truncate(req.limit.clamp(1, 200));
+            // Bound the marginal lookups: score a generous top-by-raw-count
+            // candidate pool rather than every distinct collocate type
+            // (which can be tens of thousands for a frequent node).
+            let pool = (limit * 8).max(200);
+            let mut cand: Vec<(String, u32, u32)> = scan
+                .counts
+                .iter()
+                .map(|(w, &(l, r))| (w.clone(), l, r))
+                .collect();
+            cand.sort_by(|a, b| (b.1 + b.2).cmp(&(a.1 + a.2)).then_with(|| a.0.cmp(&b.0)));
+            cand.truncate(pool);
 
-    let collocates: Vec<CollocateDto> = vec
-        .into_iter()
-        .map(|(w, l, r)| {
-            let total = l + r;
-            // Placeholder stats until we wire corpus-wide term
-            // frequencies. log2(total+1) gives a monotonic proxy that
-            // spreads the scatter's y-axis readably.
-            let score = ((total + 1) as f64).log2();
-            CollocateDto {
-                word: w,
-                pos: String::new(),
-                left_count: l,
-                right_count: r,
-                total,
-                log_dice: score,
-                mi: score,
-                z: score,
-                dist: 0,
-            }
-        })
-        .collect();
+            let words: Vec<String> = cand.iter().map(|(w, _, _)| w.clone()).collect();
+            let f_coll = index
+                .term_totals(&words, corpust_index::QueryLayer::Word)
+                .map_err(|e| format!("collocate frequency lookup failed: {e:#}"))?;
 
-    let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
+            let mut collocates: Vec<CollocateDto> = cand
+                .into_iter()
+                .map(|(w, l, r)| {
+                    let total = l + r;
+                    let fc = f_coll.get(&w).copied().unwrap_or(0);
+                    let s = corpust_index::assoc::scores(total as u64, scan.node_freq, fc, n, span);
+                    CollocateDto {
+                        word: w,
+                        pos: String::new(),
+                        left_count: l,
+                        right_count: r,
+                        total,
+                        log_dice: s.log_dice,
+                        mi: s.mi,
+                        z: s.z,
+                        dist: 0,
+                    }
+                })
+                .collect();
+            // Rank by log Dice (the UI default); the client re-sorts on
+            // demand for the other measures.
+            collocates.sort_by(|a, b| {
+                b.log_dice
+                    .partial_cmp(&a.log_dice)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.word.cmp(&b.word))
+            });
+            collocates.truncate(limit);
+
+            Ok((
+                collocates,
+                scan.node_freq,
+                scan.window_tokens,
+                scan.truncated,
+            ))
+        })?;
+
     Ok(CollocatesResult {
         collocates,
-        elapsed_ms,
-        node_hits: hits.len() as u32,
-        window_tokens,
-    })
-}
-
-/// Split a KWIC context string into collocate candidates.
-/// - whitespace-separated,
-/// - lowercased,
-/// - punctuation-trimmed at ends,
-/// - filter empty/single-char tokens,
-/// - filter pure-digit tokens.
-fn tokenize_for_collocates(s: &str) -> impl Iterator<Item = String> + '_ {
-    s.split_whitespace().filter_map(|tok| {
-        let trimmed: String = tok
-            .trim_matches(|c: char| !c.is_alphanumeric())
-            .to_lowercase();
-        if trimmed.len() < 2 {
-            return None;
-        }
-        if trimmed.chars().all(|c| c.is_ascii_digit()) {
-            return None;
-        }
-        Some(trimmed)
+        elapsed_ms: t0.elapsed().as_secs_f64() * 1000.0,
+        node_hits: node_freq.min(u32::MAX as u64) as u32,
+        window_tokens: window_tokens.min(u32::MAX as u64) as u32,
+        truncated,
     })
 }
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -151,8 +151,13 @@ pub struct Collocate {
 pub struct CollocatesResult {
     pub collocates: Vec<Collocate>,
     pub elapsed_ms: f64,
+    /// Node-term occurrences the scan covered. Equals the node's true
+    /// corpus frequency unless `truncated` is set.
     pub node_hits: u32,
     pub window_tokens: u32,
+    /// True when the safety ceiling cut the full-corpus scan short, so
+    /// the scores reflect a (large) sample rather than every occurrence.
+    pub truncated: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -44,6 +44,8 @@ export function App() {
   const [term, setTerm] = useState("linguistic");
   const [result, setResult] = useState<KwicResult | null>(null);
   const [collocates, setCollocates] = useState<Collocate[] | null>(null);
+  const [collLoading, setCollLoading] = useState(false);
+  const [collTruncated, setCollTruncated] = useState(false);
   const [collLeft, setCollLeft] = useState(5);
   const [collRight, setCollRight] = useState(5);
   const [loading, setLoading] = useState(false);
@@ -191,9 +193,12 @@ export function App() {
     if (subview !== "coll" || !activeCorpus || !term.trim()) return;
     if (!inTauri() || CORPORA.some((c) => c.id === activeCorpus.id)) {
       setCollocates(null);
+      setCollLoading(false);
+      setCollTruncated(false);
       return;
     }
     const myId = ++collReqRef.current;
+    setCollLoading(true);
     runCollocates({
       corpusId: activeCorpus.id,
       term: term.trim(),
@@ -203,11 +208,17 @@ export function App() {
       limit: 60,
     })
       .then((r) => {
-        if (myId === collReqRef.current) setCollocates(r.collocates);
+        if (myId !== collReqRef.current) return;
+        setCollocates(r.collocates);
+        setCollTruncated(r.truncated);
+        setCollLoading(false);
       })
       .catch((e) => {
         console.error("runCollocates failed:", e);
-        if (myId === collReqRef.current) setCollocates([]);
+        if (myId !== collReqRef.current) return;
+        setCollocates([]);
+        setCollTruncated(false);
+        setCollLoading(false);
       });
   };
 
@@ -386,6 +397,8 @@ export function App() {
               corpus={activeCorpus}
               term={term}
               data={collocates}
+              loading={collLoading}
+              truncated={collTruncated}
               leftWindow={collLeft}
               rightWindow={collRight}
               onWindowChange={(l, r) => {

--- a/app/src/components/analyses/CollocationsView.tsx
+++ b/app/src/components/analyses/CollocationsView.tsx
@@ -41,13 +41,19 @@ function prefRatio(c: Collocate): number {
   return (c.rightCount - c.leftCount) / c.total;
 }
 
-function niceTicks(max: number, count = 5): number[] {
-  if (max <= 0) return [0];
-  const rawStep = max / (count - 1);
+// Evenly spaced "nice" ticks across a signed domain, always landing a
+// tick on zero (start is floored to a step multiple, and zero is a
+// multiple of any step).
+function signedTicks(min: number, max: number, count = 5): number[] {
+  const span = max - min || 1;
+  const rawStep = span / (count - 1);
   const pow = Math.pow(10, Math.floor(Math.log10(rawStep)));
-  const step = Math.ceil(rawStep / pow) * pow;
+  const step = Math.ceil(rawStep / pow) * pow || 1;
+  const start = Math.floor(min / step) * step;
   const ticks: number[] = [];
-  for (let v = 0; v <= max * 1.05; v += step) ticks.push(v);
+  for (let v = start; v <= max + step * 0.5; v += step) {
+    ticks.push(Number(v.toFixed(6)));
+  }
   return ticks;
 }
 
@@ -64,6 +70,12 @@ export interface CollocationsViewProps {
    *  fixture `COLLOCATIONS` so the view still looks populated in
    *  demos / non-Tauri preview. */
   data?: Collocate[] | null;
+  /** Backend scan in flight — show a loading overlay. The full-corpus
+   *  scan can take a moment on a frequent node. */
+  loading?: boolean;
+  /** The scan hit its safety ceiling; scores are from a large sample,
+   *  not every occurrence. Surface it rather than silently capping. */
+  truncated?: boolean;
   /** Tokens on the left of the node to consider (0 = skip). Lifted
    *  to App so the backend refetch uses the same values the UI shows. */
   leftWindow?: number;
@@ -78,6 +90,8 @@ type CollSortKey = "word" | "pos" | "leftCount" | "rightCount" | "total" | "logD
 export function CollocationsView({
   term,
   data: dataProp,
+  loading = false,
+  truncated = false,
   leftWindow = 5,
   rightWindow = 5,
   onWindowChange,
@@ -111,15 +125,28 @@ export function CollocationsView({
     if (sortDir === "desc") copy.reverse();
     return copy;
   }, [rawData, sortKey, sortDir]);
-  const maxScore = useMemo(() => Math.max(1e-6, ...data.map((d) => d[metric])), [data, metric]);
+  // y-axis domain always straddles zero: MI and z-score go negative for
+  // dispreferred collocates, so the axis can't assume a 0-based range.
+  const [domMin, domMax] = useMemo(() => {
+    const scores = data.map((d) => d[metric]);
+    const lo = Math.min(0, ...scores);
+    const hi = Math.max(0, ...scores);
+    const pad = (hi - lo) * 0.05 || 1;
+    return [lo - (lo < 0 ? pad : 0), hi + pad];
+  }, [data, metric]);
   const maxTotal = useMemo(() => Math.max(1, ...data.map((d) => d.total)), [data]);
 
   const xFor = (pref: number) => M.left + ((pref + 1) / 2) * PW;
-  const yFor = (score: number) => M.top + PH - (score / (maxScore * 1.05)) * PH;
+  const yFor = (score: number) =>
+    M.top + PH - ((score - domMin) / (domMax - domMin || 1)) * PH;
   const rFor = (total: number) => 4 + (Math.sqrt(total) / Math.sqrt(maxTotal)) * 12;
   const colorOf = (pos: string) => POS_FAMILY_COLOR[posFamily(pos)];
+  // Strength meter: collocate's position within the signed domain (so a
+  // strongly negative score reads as a short bar, not a clamped stub).
+  const meterWidth = (score: number) =>
+    Math.max(4, ((score - domMin) / (domMax - domMin || 1)) * 120);
 
-  const yTicks = niceTicks(maxScore, 5);
+  const yTicks = signedTicks(domMin, domMax, 5);
   const xTicks = [-1, -0.5, 0, 0.5, 1];
   const metricLabel = metric === "logDice" ? "log-Dice" : metric === "mi" ? "MI" : "z-score";
 
@@ -129,6 +156,22 @@ export function CollocationsView({
         <div className="cx-coll-head">
           <h2 className="cx-coll-title">
             collocates of <span className="kw">{term}</span>
+            {truncated && (
+              <span
+                title="The node occurs more often than the scan ceiling; scores are from a large sample, not every occurrence."
+                style={{
+                  marginLeft: 8,
+                  fontFamily: "var(--font-mono)",
+                  fontSize: 10,
+                  fontWeight: 400,
+                  color: "var(--warn)",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.06em",
+                }}
+              >
+                · sampled
+              </span>
+            )}
           </h2>
           <div className="cx-coll-controls">
             <span>L</span>
@@ -183,7 +226,28 @@ export function CollocationsView({
           </div>
         </div>
 
-        <div className="cx-coll-graph cx-coll-svg-wrap">
+        <div className="cx-coll-graph cx-coll-svg-wrap" style={{ position: "relative" }}>
+          {loading && (
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                background: "color-mix(in oklch, var(--bg) 55%, transparent)",
+                backdropFilter: "blur(1px)",
+                zIndex: 2,
+                fontFamily: "var(--font-mono)",
+                fontSize: 12,
+                color: "var(--fg-muted)",
+                letterSpacing: "0.04em",
+                transition: "opacity var(--dur-2) var(--ease)",
+              }}
+            >
+              computing collocations…
+            </div>
+          )}
           <svg
             viewBox={`0 0 ${W} ${H}`}
             preserveAspectRatio="xMidYMid meet"
@@ -434,10 +498,7 @@ export function CollocationsView({
                 <td className="num">{c.mi.toFixed(2)}</td>
                 <td className="num">{c.z.toFixed(1)}</td>
                 <td className="num">
-                  <span
-                    className="cx-meter"
-                    style={{ width: Math.max(4, (c[metric] / maxScore) * 120) }}
-                  />
+                  <span className="cx-meter" style={{ width: meterWidth(c[metric]) }} />
                 </td>
               </tr>
             ))}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -29,6 +29,9 @@ export interface CollocatesResult {
   elapsedMs: number;
   nodeHits: number;
   windowTokens: number;
+  /** True when the full-corpus scan hit its safety ceiling, so scores
+   *  reflect a large sample rather than every node occurrence. */
+  truncated: boolean;
 }
 
 /** Raw KWIC hit as returned by the backend — distinct from the UI's

--- a/crates/corpust-index/src/assoc.rs
+++ b/crates/corpust-index/src/assoc.rs
@@ -1,0 +1,129 @@
+//! Collocation association measures.
+//!
+//! Given the windowed co-occurrence count of a collocate around a node
+//! term plus the corpus marginals, compute the standard strength scores
+//! a corpus-linguistics tool reports. Formulas follow the conventions
+//! used by LancsBox / Stefan Evert's collocation literature:
+//!
+//! - **log Dice** = `14 + log2(2·O11 / (f(node) + f(collocate)))`
+//!   (Rychlý 2008) — the LancsBox default; bounded and corpus-size
+//!   independent.
+//! - **MI** (pointwise mutual information) = `log2(O11 / E11)`.
+//! - **z-score** = `(O11 − E11) / sqrt(E11)`.
+//!
+//! where the expected co-occurrence under independence is
+//! `E11 = f(node) · span · f(collocate) / N` — `f(node)·span` is the
+//! total number of collocate slots examined across every node
+//! occurrence, and `f(collocate)/N` is the collocate's corpus-wide rate.
+//!
+//! Every result is guaranteed finite: degenerate inputs (a zero
+//! marginal, no co-occurrence) yield `0.0` rather than `NaN`/`±∞`, which
+//! matters because the scores cross a JSON IPC boundary where non-finite
+//! floats would serialise to `null` and break the UI.
+
+/// The three association scores the UI exposes.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Scores {
+    pub log_dice: f64,
+    pub mi: f64,
+    pub z: f64,
+}
+
+/// Compute association scores for one collocate.
+///
+/// - `o11`  — observed co-occurrence count (collocate seen in the node's window)
+/// - `f_node` — corpus frequency of the node term
+/// - `f_coll` — corpus frequency of the collocate
+/// - `n` — corpus size (total tokens on the surface layer)
+/// - `span` — window width in token positions (`left + right`)
+pub fn scores(o11: u64, f_node: u64, f_coll: u64, n: u64, span: u64) -> Scores {
+    let o = o11 as f64;
+    let f_n = f_node as f64;
+    let f_c = f_coll as f64;
+    let nn = n as f64;
+    let s = span as f64;
+
+    // log Dice — defined whenever there is co-occurrence and a non-zero
+    // combined marginal. Bounded above by 14 (when every node and
+    // collocate token co-occurs).
+    let log_dice = if o11 > 0 && f_node + f_coll > 0 {
+        14.0 + (2.0 * o / (f_n + f_c)).log2()
+    } else {
+        0.0
+    };
+
+    // Expected co-occurrence under independence.
+    let e11 = if n > 0 { f_n * s * f_c / nn } else { 0.0 };
+
+    let mi = if o11 > 0 && e11 > 0.0 {
+        (o / e11).log2()
+    } else {
+        0.0
+    };
+
+    let z = if e11 > 0.0 {
+        (o - e11) / e11.sqrt()
+    } else {
+        0.0
+    };
+
+    Scores { log_dice, mi, z }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All scores stay finite for degenerate inputs — they must never
+    /// reach the JSON boundary as NaN/Inf.
+    #[test]
+    fn degenerate_inputs_are_finite_zeros() {
+        for s in [
+            scores(0, 100, 50, 1000, 10), // no co-occurrence
+            scores(5, 0, 50, 1000, 10),   // node never occurs
+            scores(5, 100, 0, 1000, 10),  // collocate never occurs
+            scores(5, 100, 50, 0, 10),    // empty corpus
+            scores(0, 0, 0, 0, 0),        // everything zero
+        ] {
+            assert!(s.log_dice.is_finite(), "log_dice not finite: {s:?}");
+            assert!(s.mi.is_finite(), "mi not finite: {s:?}");
+            assert!(s.z.is_finite(), "z not finite: {s:?}");
+        }
+    }
+
+    #[test]
+    fn mi_matches_hand_computation() {
+        // O11=10, f_node=100, f_coll=200, N=10_000, span=10.
+        // E11 = 100*10*200/10000 = 20. MI = log2(10/20) = -1.
+        let s = scores(10, 100, 200, 10_000, 10);
+        assert!((s.mi - (-1.0)).abs() < 1e-9, "mi = {}", s.mi);
+        // z = (10 - 20)/sqrt(20) = -2.2360679...
+        assert!((s.z - (-2.236_067_977)).abs() < 1e-6, "z = {}", s.z);
+    }
+
+    #[test]
+    fn log_dice_matches_hand_computation() {
+        // logDice = 14 + log2(2*O11/(f_node+f_coll))
+        //         = 14 + log2(2*30/(100+200)) = 14 + log2(0.2) = 14 - 2.3219..
+        let s = scores(30, 100, 200, 10_000, 10);
+        let expected = 14.0 + (0.2_f64).log2();
+        assert!(
+            (s.log_dice - expected).abs() < 1e-9,
+            "log_dice = {}",
+            s.log_dice
+        );
+    }
+
+    /// A collocate that co-occurs far more than chance scores positively
+    /// on every measure; the inverse case (below chance) goes negative on
+    /// MI/z — the case the scatter's y-axis must render.
+    #[test]
+    fn attraction_positive_repulsion_negative() {
+        let attracted = scores(50, 100, 60, 100_000, 10);
+        assert!(attracted.mi > 0.0 && attracted.z > 0.0);
+
+        let repelled = scores(1, 100, 5000, 100_000, 10);
+        assert!(repelled.mi < 0.0, "mi = {}", repelled.mi);
+        assert!(repelled.z < 0.0, "z = {}", repelled.z);
+    }
+}

--- a/crates/corpust-index/src/lib.rs
+++ b/crates/corpust-index/src/lib.rs
@@ -16,6 +16,8 @@
 //! A stored `token_offsets` sidecar carries per-token byte offsets so KWIC
 //! context extraction is O(context) regardless of document length.
 
+pub mod assoc;
+
 use anyhow::{Context, Result};
 use corpust_annotate::{AnnotatedToken, Annotator};
 use corpust_core::{DocId, Document};
@@ -54,6 +56,11 @@ pub struct CorpusIndex {
     doc_cache: OnceLock<Vec<DocumentInfo>>,
     freq_cache: Mutex<HashMap<(QueryLayer, usize), FreqTable>>,
     dist_cache: Mutex<HashMap<(String, QueryLayer, usize), TermDistribution>>,
+    /// Cache of full-corpus collocate scans, keyed by
+    /// `(term, layer, left, right)`. The scan is the expensive part of a
+    /// collocation query (a positional pass over every node occurrence);
+    /// marginals + scores are recomputed cheaply on top.
+    colloc_cache: Mutex<HashMap<(String, QueryLayer, usize, usize), CollocateScan>>,
 }
 
 /// Top-N `(term, count)` rows plus the field's grand-total token count —
@@ -147,6 +154,27 @@ pub struct DocTermCount {
     pub token_count: u64,
 }
 
+/// Raw windowed co-occurrence counts for a collocation query, produced
+/// by a single positional pass over every occurrence of the node term.
+/// Association scores ([`assoc`]) are computed on top of this plus the
+/// corpus marginals — kept separate so the expensive scan can be cached
+/// independently of the (cheap) scoring.
+#[derive(Debug, Clone)]
+pub struct CollocateScan {
+    /// Number of node occurrences scanned. Equals the node's true corpus
+    /// frequency unless `truncated` is set.
+    pub node_freq: u64,
+    /// Per-collocate `(left_count, right_count)` within the window.
+    pub counts: HashMap<String, (u32, u32)>,
+    /// Total collocate slots actually counted (sum of left+right hits) —
+    /// the UI's "window tokens" figure.
+    pub window_tokens: u64,
+    /// True when the safety ceiling cut the scan short; scores then
+    /// reflect a (large) sample of the node's occurrences, not all of
+    /// them.
+    pub truncated: bool,
+}
+
 /// Corpus-wide distribution of a term: per-document hit counts plus a
 /// dispersion histogram over the whole corpus.
 #[derive(Debug, Clone)]
@@ -208,6 +236,7 @@ impl CorpusIndex {
             doc_cache: OnceLock::new(),
             freq_cache: Mutex::new(HashMap::new()),
             dist_cache: Mutex::new(HashMap::new()),
+            colloc_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -666,6 +695,159 @@ impl CorpusIndex {
         })
     }
 
+    /// Total token count on `layer` across the whole corpus — the `N`
+    /// denominator for association measures. O(segments): Tantivy tracks
+    /// this per inverted index, so no scan is needed.
+    pub fn layer_total_tokens(&self, layer: QueryLayer) -> Result<u64> {
+        let searcher = self.reader.searcher();
+        let field = self.layer_field(layer);
+        let mut total = 0u64;
+        for seg_reader in searcher.segment_readers() {
+            total += seg_reader.inverted_index(field)?.total_num_tokens();
+        }
+        Ok(total)
+    }
+
+    /// Corpus-wide frequency of each given term on `layer`. Used to fetch
+    /// the `f(node)` / `f(collocate)` marginals for scoring. Terms absent
+    /// from the index map to `0`.
+    pub fn term_totals(&self, terms: &[String], layer: QueryLayer) -> Result<HashMap<String, u64>> {
+        let searcher = self.reader.searcher();
+        let field = self.layer_field(layer);
+        let mut out: HashMap<String, u64> = HashMap::with_capacity(terms.len());
+        for term in terms {
+            let term_obj = Term::from_field_text(field, term);
+            let mut sum = 0u64;
+            for seg_reader in searcher.segment_readers() {
+                let inv = seg_reader.inverted_index(field)?;
+                if let Some(mut postings) =
+                    inv.read_postings(&term_obj, IndexRecordOption::WithFreqs)?
+                {
+                    loop {
+                        let doc = postings.doc();
+                        if doc == TERMINATED {
+                            break;
+                        }
+                        sum += postings.term_freq() as u64;
+                        postings.advance();
+                    }
+                }
+            }
+            out.insert(term.clone(), sum);
+        }
+        Ok(out)
+    }
+
+    /// Count surface-form collocates in a `[left, right]` token window
+    /// around **every** occurrence of `term` on `layer`, in a single
+    /// positional pass (one stored-document fetch per document, not per
+    /// hit). Collocate candidates are normalised the same way as
+    /// [`tokenize_for_collocates`]: lowercased, edge-punctuation trimmed,
+    /// single-character and pure-digit tokens dropped.
+    ///
+    /// `max_nodes` is a safety ceiling: if more than that many node
+    /// occurrences are seen the scan stops early and the result is marked
+    /// `truncated`. Pass a large value (or `usize::MAX`) for a full scan.
+    ///
+    /// Results are cached on `(term, layer, left, right)` since the scan
+    /// is the costly part of a collocation query.
+    pub fn collocate_counts(
+        &self,
+        term: &str,
+        layer: QueryLayer,
+        left: usize,
+        right: usize,
+        max_nodes: usize,
+    ) -> Result<CollocateScan> {
+        let (query_field, lookup_term) = match layer {
+            QueryLayer::Word => (self.fields.body, term.to_lowercase()),
+            QueryLayer::Lemma => (self.fields.body_lemma, term.to_lowercase()),
+            QueryLayer::Pos => (self.fields.body_pos, term.to_string()),
+        };
+        let cache_key = (lookup_term.clone(), layer, left, right);
+        if let Some(cached) = self
+            .colloc_cache
+            .lock()
+            .expect("colloc_cache poisoned")
+            .get(&cache_key)
+        {
+            return Ok(cached.clone());
+        }
+
+        let searcher = self.reader.searcher();
+        let term_obj = Term::from_field_text(query_field, &lookup_term);
+
+        let mut counts: HashMap<String, (u32, u32)> = HashMap::new();
+        let mut node_freq: u64 = 0;
+        let mut window_tokens: u64 = 0;
+        let mut truncated = false;
+        let mut positions_buf: Vec<u32> = Vec::new();
+
+        'segments: for (seg_ord, seg_reader) in searcher.segment_readers().iter().enumerate() {
+            let inv_idx = seg_reader.inverted_index(query_field)?;
+            let Some(mut postings) =
+                inv_idx.read_postings(&term_obj, IndexRecordOption::WithFreqsAndPositions)?
+            else {
+                continue;
+            };
+
+            loop {
+                let doc = postings.doc();
+                if doc == TERMINATED {
+                    continue 'segments;
+                }
+
+                let doc_addr = DocAddress::new(seg_ord as u32, doc);
+                let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
+                let body = retrieved
+                    .get_first(self.fields.body)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                let offsets_bytes = retrieved
+                    .get_first(self.fields.token_offsets)
+                    .and_then(|v| v.as_bytes())
+                    .unwrap_or_default();
+                let offsets = bytes_to_offsets(offsets_bytes);
+
+                positions_buf.clear();
+                postings.positions(&mut positions_buf);
+
+                for &pos in &positions_buf {
+                    if node_freq as usize >= max_nodes {
+                        truncated = true;
+                        break 'segments;
+                    }
+                    node_freq += 1;
+                    let p = pos as usize;
+                    for w in window_side(body, &offsets, p, left, Side::Left) {
+                        let e = counts.entry(w).or_default();
+                        e.0 += 1;
+                        window_tokens += 1;
+                    }
+                    for w in window_side(body, &offsets, p, right, Side::Right) {
+                        let e = counts.entry(w).or_default();
+                        e.1 += 1;
+                        window_tokens += 1;
+                    }
+                }
+
+                postings.advance();
+            }
+        }
+
+        let scan = CollocateScan {
+            node_freq,
+            counts,
+            window_tokens,
+            truncated,
+        };
+        self.colloc_cache
+            .lock()
+            .expect("colloc_cache poisoned")
+            .insert(cache_key, scan.clone());
+        Ok(scan)
+    }
+
     /// Per-document hit counts and a corpus-wide dispersion histogram for
     /// a single term on `layer`, in one pass over the term's postings.
     ///
@@ -883,6 +1065,60 @@ fn window(
         window_tokens[hit_idx].to_string(),
         window_tokens[hit_idx + 1..].join(" "),
     ))
+}
+
+/// Which side of the node a window extends to.
+enum Side {
+    Left,
+    Right,
+}
+
+/// Extract and normalise the collocate candidates within `count` token
+/// positions on one `side` of node position `p`. Reads surface text from
+/// `body` via `offsets`, then applies [`tokenize_for_collocates`].
+///
+/// Returns an empty vec when `p` is out of range or the side is empty
+/// (node at a document edge, or `count == 0`).
+fn window_side(body: &str, offsets: &[u32], p: usize, count: usize, side: Side) -> Vec<String> {
+    if count == 0 || p >= offsets.len() {
+        return Vec::new();
+    }
+    let (start, end) = match side {
+        // positions [p-count, p)
+        Side::Left => (p.saturating_sub(count), p),
+        // positions (p, p+count]
+        Side::Right => (p + 1, (p + 1 + count).min(offsets.len())),
+    };
+    if start >= end {
+        return Vec::new();
+    }
+    let byte_start = offsets[start] as usize;
+    let byte_end = if end < offsets.len() {
+        offsets[end] as usize
+    } else {
+        body.len()
+    };
+    tokenize_for_collocates(&body[byte_start..byte_end]).collect()
+}
+
+/// Split a window substring into collocate candidates:
+/// whitespace/punctuation-delimited, lowercased, edge-punctuation
+/// trimmed, dropping empty/single-character and pure-digit tokens. Kept
+/// in sync with the equivalent normalisation the Tauri command applied
+/// before collocation moved into the index.
+fn tokenize_for_collocates(s: &str) -> impl Iterator<Item = String> + '_ {
+    s.unicode_words().filter_map(|tok| {
+        let trimmed: String = tok
+            .trim_matches(|c: char| !c.is_alphanumeric())
+            .to_lowercase();
+        if trimmed.chars().count() < 2 {
+            return None;
+        }
+        if trimmed.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        Some(trimmed)
+    })
 }
 
 fn offsets_to_bytes(offsets: &[u32]) -> Vec<u8> {
@@ -1327,6 +1563,54 @@ mod tests {
         assert_eq!(docs[0].token_count, 6); // the cat sat on the mat
         assert_eq!(docs[1].doc_id, 1);
         assert_eq!(docs[1].token_count, 5); // the dog and the cat
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn collocate_counts_tallies_window_sides() {
+        // doc0: the(0) cat(1) sat(2) on(3) the(4) mat(5)
+        // doc1: the(0) dog(1) and(2) the(3) cat(4)
+        let (tmp, idx) = two_doc_index();
+
+        let scan = idx
+            .collocate_counts("the", QueryLayer::Word, 1, 1, usize::MAX)
+            .unwrap();
+
+        assert_eq!(scan.node_freq, 4, "the occurs 4×");
+        assert!(!scan.truncated);
+        // cat sits immediately right of "the" twice (doc0 p0, doc1 p3).
+        assert_eq!(scan.counts.get("cat"), Some(&(0, 2)));
+        // on/and precede a "the"; mat/dog follow one.
+        assert_eq!(scan.counts.get("on"), Some(&(1, 0)));
+        assert_eq!(scan.counts.get("and"), Some(&(1, 0)));
+        assert_eq!(scan.counts.get("mat"), Some(&(0, 1)));
+        assert_eq!(scan.counts.get("dog"), Some(&(0, 1)));
+        // 2(cat) + 1(on) + 1(and) + 1(mat) + 1(dog) collocate slots filled.
+        assert_eq!(scan.window_tokens, 6);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn collocate_marginals_and_truncation() {
+        let (tmp, idx) = two_doc_index();
+
+        // N = every surface token across both docs (6 + 5).
+        assert_eq!(idx.layer_total_tokens(QueryLayer::Word).unwrap(), 11);
+
+        let totals = idx
+            .term_totals(&["the".to_string(), "cat".to_string()], QueryLayer::Word)
+            .unwrap();
+        assert_eq!(totals.get("the"), Some(&4));
+        assert_eq!(totals.get("cat"), Some(&2));
+
+        // Safety ceiling stops the scan early and flags it.
+        let scan = idx
+            .collocate_counts("the", QueryLayer::Word, 1, 1, 2)
+            .unwrap();
+        assert_eq!(scan.node_freq, 2);
+        assert!(scan.truncated);
+
         let _ = std::fs::remove_dir_all(&tmp);
     }
 


### PR DESCRIPTION
Carves the highest-leverage gap out of the LancsBox parity analysis (#23): collocation statistics were placeholders.

## Problem
`run_collocates` ranked collocates by raw left+right count and set `logDice`, `mi`, and `z` all to the same `log2(total+1)` stub — the UI rendered statistical measures that were fake, over a KWIC sample capped at 5000 node hits.

## What changed
**Backend**
- New `corpust_index::assoc` module — pure, unit-tested `scores(o11, f_node, f_coll, n, span)` implementing **log Dice** (LancsBox default), **MI**, and **z-score**. All results are guaranteed finite (degenerate inputs → `0.0`) so non-finite floats can't reach the JSON IPC boundary and break `toFixed`.
- New index methods: `collocate_counts` (a **full-corpus** positional scan — one stored-doc fetch per document, not per hit — with a 1M-occurrence safety ceiling and a `truncated` flag, cached like the existing query caches), `layer_total_tokens` (corpus size `N`, O(1) via Tantivy `total_num_tokens`), and `term_totals` (the `f(node)` / `f(collocate)` marginals).
- `run_collocates` is now **async** (`spawn_blocking`, mirroring `build_index`) so the scan never blocks the UI thread. It scores a bounded top-by-count candidate pool, ranks by log Dice, and surfaces `truncated`.

**Frontend**
- Loading overlay on the scatter while the scan runs.
- Scatter y-axis now straddles zero (real MI/z go negative for dispreferred collocates) with a zero gridline + signed ticks; strength meter normalized within the signed domain.
- "· sampled" badge when a scan hit the safety ceiling.

## Notes / scope
- Collocates are surface forms, so `f(collocate)` and `N` are taken on the word layer regardless of the node's query layer; `f(node)` is the scanned occurrence count.
- The candidate pool is bounded (top `8×limit`, min 200) to cap marginal lookups — a frequent node can have tens of thousands of distinct collocate types. Documented in code; could rank-by-measure in a follow-up.
- POS coloring (`pos` field) still left empty — deferred with the rest of the UI polish (#6).

## Verification
- `cargo test` (assoc math checked against hand-computed MI = −1, z = −2.236; collocate scan window counts; marginals + truncation), `cargo clippy --workspace`, `cargo fmt --check` — clean.
- `npm run build` + `npm test` (55) green.
- Manual GUI eyeballing of the live numbers/loading/axis to follow.