### PR TITLE
Run backend queries off the UI thread + loading states everywhere

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -73,8 +73,16 @@ fn emit_failure(app: &AppHandle, started: Instant, message: &str) {
 /// build step writes `<slug>/metadata.json` next to the index. The
 /// in-memory `AppState.corpora` registry is only a cache of opened
 /// handles; we fall back to disk for everything else.
+/// Async so scanning the data directory + parsing each metadata sidecar
+/// doesn't stall the UI thread at startup with many corpora present.
 #[tauri::command]
-pub fn list_corpora() -> Result<Vec<CorpusMeta>, String> {
+pub async fn list_corpora() -> Result<Vec<CorpusMeta>, String> {
+    tauri::async_runtime::spawn_blocking(list_corpora_inner)
+        .await
+        .map_err(|e| format!("list corpora task failed to join: {e}"))?
+}
+
+fn list_corpora_inner() -> Result<Vec<CorpusMeta>, String> {
     let root = match paths::corpora_root() {
         Ok(p) => p,
         Err(e) => return Err(format!("resolving data dir: {e:#}")),
@@ -105,21 +113,28 @@ pub fn list_corpora() -> Result<Vec<CorpusMeta>, String> {
 /// Open a corpus by slug (the `id` field returned from `list_corpora`
 /// or `build_index`). Registers the handle in `AppState` so subsequent
 /// KWIC / collocate calls hit the same instance.
+/// Async so opening a large index from disk (Tantivy reader setup) runs
+/// off the UI thread when the user switches corpora.
 #[tauri::command]
-pub fn open_corpus(state: State<'_, AppState>, id: String) -> Result<CorpusMeta, String> {
-    let (index, meta) = load_from_disk(&id)?;
-    state
-        .corpora
-        .lock()
-        .expect("corpus registry poisoned")
-        .insert(
-            id,
-            OpenedCorpus {
-                index,
-                meta: meta.clone(),
-            },
-        );
-    Ok(meta)
+pub async fn open_corpus(app: AppHandle, id: String) -> Result<CorpusMeta, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        let (index, meta) = load_from_disk(&id)?;
+        state
+            .corpora
+            .lock()
+            .expect("corpus registry poisoned")
+            .insert(
+                id,
+                OpenedCorpus {
+                    index,
+                    meta: meta.clone(),
+                },
+            );
+        Ok(meta)
+    })
+    .await
+    .map_err(|e| format!("open corpus task failed to join: {e}"))?
 }
 
 /// Async so the full-corpus collocation scan runs on a worker thread —
@@ -235,8 +250,20 @@ fn run_collocates_inner(
     })
 }
 
+/// Async so the KWIC scan runs off the UI thread; a frequent term in a
+/// large corpus would otherwise freeze the window while the loading
+/// state is supposed to be showing.
 #[tauri::command]
-pub fn run_kwic(state: State<'_, AppState>, req: KwicRequest) -> Result<KwicResult, String> {
+pub async fn run_kwic(app: AppHandle, req: KwicRequest) -> Result<KwicResult, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        run_kwic_inner(&state, &req)
+    })
+    .await
+    .map_err(|e| format!("kwic task failed to join: {e}"))?
+}
+
+fn run_kwic_inner(state: &State<'_, AppState>, req: &KwicRequest) -> Result<KwicResult, String> {
     let context = if req.context == 0 {
         DEFAULT_CONTEXT
     } else {
@@ -249,7 +276,7 @@ pub fn run_kwic(state: State<'_, AppState>, req: KwicRequest) -> Result<KwicResu
         .limit(limit);
 
     let t0 = Instant::now();
-    let hits = with_corpus(&state, &req.corpus_id, |index| {
+    let hits = with_corpus(state, &req.corpus_id, |index| {
         run_core_kwic(index, kreq).map_err(|e| format!("kwic failed: {e:#}"))
     })?;
     let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
@@ -273,12 +300,26 @@ pub fn run_kwic(state: State<'_, AppState>, req: KwicRequest) -> Result<KwicResu
 
 /// List every document in a corpus with its path + token count. Backs
 /// the CorpusDetail document table.
+/// Async so the document-listing scan (reads every doc's stored fields)
+/// stays off the UI thread on large corpora.
 #[tauri::command]
-pub fn list_documents(
-    state: State<'_, AppState>,
+pub async fn list_documents(
+    app: AppHandle,
     corpus_id: String,
 ) -> Result<Vec<DocumentInfoDto>, String> {
-    with_corpus(&state, &corpus_id, |index| {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        list_documents_inner(&state, &corpus_id)
+    })
+    .await
+    .map_err(|e| format!("list documents task failed to join: {e}"))?
+}
+
+fn list_documents_inner(
+    state: &State<'_, AppState>,
+    corpus_id: &str,
+) -> Result<Vec<DocumentInfoDto>, String> {
+    with_corpus(state, corpus_id, |index| {
         let docs = index
             .list_documents()
             .map_err(|e| format!("listing documents: {e:#}"))?;
@@ -298,10 +339,26 @@ pub fn list_documents(
 
 /// Corpus-wide top-N term frequencies on a layer. Backs the FrequencyView
 /// word / POS tables.
+/// Async so the term-dictionary scan (the fallback when no precomputed
+/// sidecar exists) runs off the UI thread — Tauri puts sync commands on
+/// the main thread, where switching the word/lemma/POS layer would
+/// otherwise freeze the window. The frontend shows a loading state.
 #[tauri::command]
-pub fn run_frequencies(
-    state: State<'_, AppState>,
+pub async fn run_frequencies(
+    app: AppHandle,
     req: FrequenciesRequest,
+) -> Result<FrequenciesResult, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        run_frequencies_inner(&state, &req)
+    })
+    .await
+    .map_err(|e| format!("frequencies task failed to join: {e}"))?
+}
+
+fn run_frequencies_inner(
+    state: &State<'_, AppState>,
+    req: &FrequenciesRequest,
 ) -> Result<FrequenciesResult, String> {
     let limit = req.limit.clamp(1, 1000);
     let layer: QueryLayer = req.layer.into();
@@ -311,7 +368,7 @@ pub fn run_frequencies(
     // (or if the request asks for more rows than were precomputed).
     let (rows, total_tokens) = match load_precomputed_frequencies(&req.corpus_id, layer, limit) {
         Some(table) => table,
-        None => with_corpus(&state, &req.corpus_id, |index| {
+        None => with_corpus(state, &req.corpus_id, |index| {
             index
                 .frequencies(layer, limit)
                 .map_err(|e| format!("frequencies failed: {e:#}"))
@@ -335,14 +392,29 @@ pub fn run_frequencies(
 
 /// Per-document hit counts + a corpus-wide dispersion histogram for a
 /// term. Backs the FrequencyView document table and dispersion strip.
+/// Async for the same reason as [`run_frequencies`]: the per-term
+/// postings walk that builds the dispersion histogram + per-doc counts
+/// must stay off the UI thread.
 #[tauri::command]
-pub fn run_term_distribution(
-    state: State<'_, AppState>,
+pub async fn run_term_distribution(
+    app: AppHandle,
     req: TermDistRequest,
+) -> Result<TermDistResult, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        run_term_distribution_inner(&state, &req)
+    })
+    .await
+    .map_err(|e| format!("term distribution task failed to join: {e}"))?
+}
+
+fn run_term_distribution_inner(
+    state: &State<'_, AppState>,
+    req: &TermDistRequest,
 ) -> Result<TermDistResult, String> {
     let buckets = req.buckets.clamp(1, 1000);
     let t0 = Instant::now();
-    let dist = with_corpus(&state, &req.corpus_id, |index| {
+    let dist = with_corpus(state, &req.corpus_id, |index| {
         index
             .term_distribution(&req.term, req.layer.into(), buckets)
             .map_err(|e| format!("term distribution failed: {e:#}"))
@@ -366,20 +438,32 @@ pub fn run_term_distribution(
 
 /// Re-expand the context around a single KWIC hit to a wider window.
 /// Backs the ContextDrawer.
+/// Async because locating the document is a linear scan over stored doc
+/// ids; on a large corpus that's enough to stutter the UI if it ran on
+/// the main thread when the drawer opens.
 #[tauri::command]
-pub fn expand_context(
-    state: State<'_, AppState>,
-    req: ExpandRequest,
+pub async fn expand_context(app: AppHandle, req: ExpandRequest) -> Result<ExpandedContext, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        expand_context_inner(&state, &req)
+    })
+    .await
+    .map_err(|e| format!("expand context task failed to join: {e}"))?
+}
+
+fn expand_context_inner(
+    state: &State<'_, AppState>,
+    req: &ExpandRequest,
 ) -> Result<ExpandedContext, String> {
     let context = req.context.clamp(1, 500);
-    let found = with_corpus(&state, &req.corpus_id, |index| {
+    let found = with_corpus(state, &req.corpus_id, |index| {
         index
             .context_at(req.doc_id, req.position, context)
             .map_err(|e| format!("context lookup failed: {e:#}"))
     })?;
     // Resolve the path separately so the drawer can show a title even if
     // the position fell out of range.
-    let path = with_corpus(&state, &req.corpus_id, |index| {
+    let path = with_corpus(state, &req.corpus_id, |index| {
         Ok(index
             .list_documents()
             .map_err(|e| format!("listing documents: {e:#}"))?

--- a/app/src/components/analyses/CorpusDetail.tsx
+++ b/app/src/components/analyses/CorpusDetail.tsx
@@ -29,16 +29,22 @@ function orDash(value: string | number | null) {
 export function CorpusDetail({ corpus, onDismiss }: CorpusDetailProps) {
   const wps = Math.round(corpus.tokenCount / (corpus.buildMs / 1000));
 
+  const isLive = hasLiveData(corpus.id);
   const [docs, setDocs] = useState<DocumentInfo[] | null>(null);
+  const [docsLoading, setDocsLoading] = useState(false);
   useEffect(() => {
     setDocs(null);
     if (!hasLiveData(corpus.id)) return;
     let cancelled = false;
+    setDocsLoading(true);
     listDocuments(corpus.id)
       .then((d) => {
         if (!cancelled) setDocs(d);
       })
-      .catch((e) => console.error("listDocuments failed:", e));
+      .catch((e) => console.error("listDocuments failed:", e))
+      .finally(() => {
+        if (!cancelled) setDocsLoading(false);
+      });
     return () => {
       cancelled = true;
     };
@@ -140,8 +146,15 @@ export function CorpusDetail({ corpus, onDismiss }: CorpusDetailProps) {
 
       <div className="cx-section-h">
         <span>documents</span>
-        <span className="sub">{docRows.length.toLocaleString()} files</span>
+        <span className="sub">
+          {isLive && docsLoading ? "loading…" : `${docRows.length.toLocaleString()} files`}
+        </span>
       </div>
+      {isLive && docsLoading ? (
+        <div className="cx-loading-row">
+          <span className="cx-spinner" /> loading documents…
+        </div>
+      ) : (
       <table className="cx-doc-table">
         <thead>
           <tr>
@@ -164,6 +177,7 @@ export function CorpusDetail({ corpus, onDismiss }: CorpusDetailProps) {
           ))}
         </tbody>
       </table>
+      )}
     </div>
   );
 }

--- a/app/src/components/analyses/FrequencyView.tsx
+++ b/app/src/components/analyses/FrequencyView.tsx
@@ -37,18 +37,27 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
   const [by, setBy] = useState<FreqBy>("word");
   const [liveFreq, setLiveFreq] = useState<FreqResultRow[] | null>(null);
   const [liveDist, setLiveDist] = useState<TermDistResult | null>(null);
+  const [freqLoading, setFreqLoading] = useState(false);
+  const [distLoading, setDistLoading] = useState(false);
 
   // Corpus-wide term frequencies on the active layer; refetch when the
-  // corpus or the word/POS toggle changes. Fixtures fall through below.
+  // corpus or the word/POS toggle changes. The backend command is async
+  // (off the UI thread), so the only thing freezing here is React state —
+  // the loading flag drives a spinner instead of a frozen table. Fixtures
+  // fall through below.
   useEffect(() => {
     setLiveFreq(null);
     if (!hasLiveData(corpus.id)) return;
     let cancelled = false;
+    setFreqLoading(true);
     runFrequencies({ corpusId: corpus.id, layer: by, limit: TOP_N })
       .then((r) => {
         if (!cancelled) setLiveFreq(r.rows);
       })
-      .catch((e) => console.error("runFrequencies failed:", e));
+      .catch((e) => console.error("runFrequencies failed:", e))
+      .finally(() => {
+        if (!cancelled) setFreqLoading(false);
+      });
     return () => {
       cancelled = true;
     };
@@ -59,16 +68,21 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
     setLiveDist(null);
     if (!hasLiveData(corpus.id) || !term.trim()) return;
     let cancelled = false;
+    setDistLoading(true);
     runTermDistribution({ corpusId: corpus.id, term: term.trim(), layer: by, buckets: BUCKETS })
       .then((r) => {
         if (!cancelled) setLiveDist(r);
       })
-      .catch((e) => console.error("runTermDistribution failed:", e));
+      .catch((e) => console.error("runTermDistribution failed:", e))
+      .finally(() => {
+        if (!cancelled) setDistLoading(false);
+      });
     return () => {
       cancelled = true;
     };
   }, [corpus.id, term, by]);
 
+  const isLive = hasLiveData(corpus.id);
   const fixtureDispersion = useMemo(() => makeDispersion(42), []);
 
   // --- Normalise live or fixture data into uniform render rows. ---
@@ -130,7 +144,12 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
             <div className="cx-card-meta">n = {corpus.tokenCount.toLocaleString()} tokens</div>
           </div>
           <div className="cx-card-body">
-            {freqRows.map((row) => {
+            {isLive && freqLoading ? (
+              <div className="cx-loading-row">
+                <span className="cx-spinner" /> computing frequencies…
+              </div>
+            ) : (
+            freqRows.map((row) => {
               const w = (row.count / maxCount) * 100;
               return (
                 <div key={row.primary} className="cx-freq-bar-row">
@@ -142,7 +161,8 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
                   <span className="pct">{row.pct.toFixed(2)}%</span>
                 </div>
               );
-            })}
+            })
+            )}
           </div>
         </div>
 
@@ -156,6 +176,12 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
             </div>
           </div>
           <div className="cx-card-body">
+            {isLive && distLoading ? (
+              <div className="cx-loading-row">
+                <span className="cx-spinner" /> computing dispersion…
+              </div>
+            ) : (
+            <>
             <div className="cx-disp">
               {dispMarks.map((pct, i) => (
                 <div key={i} className="cx-disp-mark" style={{ left: `${pct}%` }} />
@@ -187,6 +213,8 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
                 <span className="pct">{d.per1m.toFixed(1)}/M</span>
               </div>
             ))}
+            </>
+            )}
           </div>
         </div>
       </div>

--- a/app/src/components/kwic/ContextDrawer.tsx
+++ b/app/src/components/kwic/ContextDrawer.tsx
@@ -21,7 +21,9 @@ export interface ContextDrawerProps {
 const EXPAND_CONTEXT = 45;
 
 export function ContextDrawer({ hit, corpus, onClose, onPrev, onNext }: ContextDrawerProps) {
+  const isLive = hasLiveData(corpus.id);
   const [live, setLive] = useState<ExpandedContext | null>(null);
+  const [loading, setLoading] = useState(false);
 
   // Pull a wider context window from the backend for real corpora. Fixture
   // corpora fall through to the `EXPANDED` demo map below.
@@ -29,6 +31,7 @@ export function ContextDrawer({ hit, corpus, onClose, onPrev, onNext }: ContextD
     setLive(null);
     if (!hasLiveData(corpus.id) || hit.hitPos == null) return;
     let cancelled = false;
+    setLoading(true);
     expandContext({
       corpusId: corpus.id,
       docId: Number(hit.docId),
@@ -40,6 +43,9 @@ export function ContextDrawer({ hit, corpus, onClose, onPrev, onNext }: ContextD
       })
       .catch((e) => {
         console.error("expandContext failed:", e);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
       });
     return () => {
       cancelled = true;
@@ -59,6 +65,25 @@ export function ContextDrawer({ hit, corpus, onClose, onPrev, onNext }: ContextD
         <span style={{ color: "var(--fg-muted)" }}>{live.before} </span>
         <span className="cx-drawer-hit">{live.hit}</span>
         <span style={{ color: "var(--fg-muted)" }}> {live.after}</span>
+      </DrawerShell>
+    );
+  }
+
+  // Live corpus, context not yet in — show a wheel rather than the
+  // fixture text (which would be a different document entirely).
+  if (isLive) {
+    return (
+      <DrawerShell
+        docTitle="loading…"
+        docMeta={loading ? "fetching context" : "no context available"}
+        pos={hit.hitPos ?? hit.pos}
+        onClose={onClose}
+        onPrev={onPrev}
+        onNext={onNext}
+      >
+        <div className="cx-loading-row">
+          <span className="cx-spinner" /> loading context…
+        </div>
       </DrawerShell>
     );
   }

--- a/app/src/components/kwic/KwicTable.tsx
+++ b/app/src/components/kwic/KwicTable.tsx
@@ -50,7 +50,9 @@ export function KwicTable({
   if (loading && !result) {
     return (
       <div className="cx-results-empty">
-        <span>running query…</span>
+        <div className="cx-loading-row">
+          <span className="cx-spinner" /> running query…
+        </div>
       </div>
     );
   }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -381,6 +381,22 @@
 .cx-results-empty-sub { font-size: 11px; color: var(--fg-subtle); font-family: var(--font-mono); }
 .cx-results-empty-hint { margin-top: 14px; font-size: 11px; color: var(--fg-subtle); display: flex; gap: 6px; align-items: center; }
 
+/* Small inline loading wheel — used wherever an async backend query is
+   in flight (frequency tables, dispersion). */
+.cx-spinner {
+  width: 16px; height: 16px; border-radius: 50%;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  animation: cx-spin var(--dur-3, 280ms) linear infinite;
+}
+.cx-loading-row {
+  display: flex; align-items: center; gap: 8px;
+  color: var(--fg-muted); font-size: 12px; font-family: var(--font-mono);
+  padding: 18px 2px;
+}
+@keyframes cx-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .cx-spinner { animation-duration: 1.2s; } }
+
 .cx-kwic-col { flex: 1; overflow: auto; min-width: 0; position: relative; }
 
 .cx-kwic-sort-bar {


### PR DESCRIPTION
Fixes the UI freezing when running backend queries — most visibly when switching the frequency word/POS/lemma layer.

## Root cause
Several `#[tauri::command]`s were synchronous. Tauri runs sync commands on the main (UI) thread, so any term-dictionary scan or postings walk froze the window. Switching the frequency layer fired two of them (`run_frequencies` + `run_term_distribution`) back to back.

## Backend — every blocking command is now async
`spawn_blocking` (mirroring the existing `build_index` pattern) so the index/I-O work stays synchronous but runs off the UI thread:
- `run_kwic`, `run_frequencies`, `run_term_distribution`, `expand_context`, `list_documents`, `open_corpus`, `list_corpora`
- (`run_collocates` and `build_index` already were async)

## Frontend — a loading wheel on every async surface
New reusable `.cx-spinner` (honors `prefers-reduced-motion`):
- **FrequencyView** — spinners on the frequency table and the dispersion/top-docs card; layer switches show the wheel instead of locking.
- **CorpusDetail** — spinner on the documents table.
- **ContextDrawer** — spinner while expanding a hit.
- **KWIC** — existing "running query…" placeholder now carries the spinner.
- **Collocations** — already had its overlay (#25).

Also fixes a latent bug: live corpora were briefly flashing **fixture** data during the load (which used to be an instant main-thread block); the loading gate now suppresses that.

## Verification
- `cargo build` / `cargo clippy --workspace --all-targets` / `cargo fmt --check` — clean.
- Backend tests: index 24 / io 12 / cli 7 / tauri 4. Frontend: build + 55 tests. All green.
- Manual feel-test of layer switching / drawer to follow.