### PR TITLE
Collocation viz overhaul + word tree + distance view

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -6,11 +6,11 @@
 //! returned `corpusId` / `taskId` handles.
 
 use crate::{
-    AppState, BuildRequest, Collocate as CollocateDto, CollocatesRequest, CollocatesResult,
-    CorpusMeta, CorpusMetaEnvelope, DocTermCount as DocTermCountDto,
-    DocumentInfo as DocumentInfoDto, ExpandRequest, ExpandedContext, FreqRow, FrequenciesRequest,
-    FrequenciesResult, KwicHit as KwicHitDto, KwicRequest, KwicResult, OpenedCorpus, TaggerKind,
-    TermDistRequest, TermDistResult,
+    AppState, BuildRequest, Collocate as CollocateDto, CollocateDistanceRequest,
+    CollocateDistanceResult, CollocatesRequest, CollocatesResult, CorpusMeta, CorpusMetaEnvelope,
+    DistanceRow, DocTermCount as DocTermCountDto, DocumentInfo as DocumentInfoDto, ExpandRequest,
+    ExpandedContext, FreqRow, FrequenciesRequest, FrequenciesResult, KwicHit as KwicHitDto,
+    KwicRequest, KwicResult, OpenedCorpus, TaggerKind, TermDistRequest, TermDistResult,
 };
 use corpust_annotate::{Annotator, treetagger::TreeTagger};
 use corpust_index::{CorpusIndex, DEFAULT_CONTEXT, QueryLayer};
@@ -432,6 +432,67 @@ fn run_term_distribution_inner(
             .collect(),
         dispersion: dist.dispersion,
         total_hits: dist.total_hits,
+        elapsed_ms: t0.elapsed().as_secs_f64() * 1000.0,
+    })
+}
+
+/// Per-collocate counts bucketed by signed distance from the node, for
+/// the collocation-by-distance heatmap. Async — full positional scan.
+#[tauri::command]
+pub async fn run_collocate_distance(
+    app: AppHandle,
+    req: CollocateDistanceRequest,
+) -> Result<CollocateDistanceResult, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app.state::<AppState>();
+        run_collocate_distance_inner(&state, &req)
+    })
+    .await
+    .map_err(|e| format!("collocate distance task failed to join: {e}"))?
+}
+
+fn run_collocate_distance_inner(
+    state: &State<'_, AppState>,
+    req: &CollocateDistanceRequest,
+) -> Result<CollocateDistanceResult, String> {
+    const MAX_NODE_OCCURRENCES: usize = 1_000_000;
+    let lw = req.left_window.min(15);
+    let rw = req.right_window.min(15);
+    if lw == 0 && rw == 0 {
+        return Err("distance window must include at least one side".to_owned());
+    }
+    let layer: QueryLayer = req.layer.into();
+    let limit = req.limit.clamp(1, 60);
+    let t0 = Instant::now();
+
+    let (offsets, mut rows, node_freq, truncated) = with_corpus(state, &req.corpus_id, |index| {
+        let prof = index
+            .collocate_by_distance(&req.term, layer, lw, rw, MAX_NODE_OCCURRENCES)
+            .map_err(|e| format!("distance scan failed: {e:#}"))?;
+        let rows: Vec<DistanceRow> = prof
+            .rows
+            .into_iter()
+            .map(|(word, counts)| {
+                let total = counts.iter().sum();
+                DistanceRow {
+                    word,
+                    total,
+                    counts,
+                }
+            })
+            .collect();
+        Ok((prof.offsets, rows, prof.node_freq, prof.truncated))
+    })?;
+
+    // Keep the busiest collocates; the heatmap can't show thousands.
+    rows.sort_by(|a, b| b.total.cmp(&a.total).then_with(|| a.word.cmp(&b.word)));
+    rows.truncate(limit);
+
+    Ok(CollocateDistanceResult {
+        offsets,
+        rows,
+        node_hits: node_freq.min(u32::MAX as u64) as u32,
+        truncated,
         elapsed_ms: t0.elapsed().as_secs_f64() * 1000.0,
     })
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ pub fn run() {
             commands::list_documents,
             commands::run_frequencies,
             commands::run_term_distribution,
+            commands::run_collocate_distance,
             commands::expand_context,
         ])
         .run(tauri::generate_context!())
@@ -260,6 +261,40 @@ pub struct TermDistResult {
     pub doc_counts: Vec<DocTermCount>,
     pub dispersion: Vec<u32>,
     pub total_hits: u64,
+    pub elapsed_ms: f64,
+}
+
+// ---- Collocation by distance (positional profile) ----
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollocateDistanceRequest {
+    pub corpus_id: String,
+    pub term: String,
+    pub layer: QueryLayer,
+    pub left_window: usize,
+    pub right_window: usize,
+    /// How many of the busiest collocates to return rows for.
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DistanceRow {
+    pub word: String,
+    pub total: u32,
+    /// One count per offset in `offsets` (same length/order).
+    pub counts: Vec<u32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CollocateDistanceResult {
+    /// Signed offsets the columns represent, e.g. `[-3,-2,-1,1,2,3]`.
+    pub offsets: Vec<i32>,
+    pub rows: Vec<DistanceRow>,
+    pub node_hits: u32,
+    pub truncated: bool,
     pub elapsed_ms: f64,
 }
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -14,6 +14,8 @@ import { KwicTable } from "@/components/kwic/KwicTable";
 import { HitDensityGutter } from "@/components/kwic/HitDensityGutter";
 import { ContextDrawer } from "@/components/kwic/ContextDrawer";
 import { CollocationsView } from "@/components/analyses/CollocationsView";
+import { CollocationDistance } from "@/components/analyses/CollocationDistance";
+import { WordTree } from "@/components/analyses/WordTree";
 import { FrequencyView } from "@/components/analyses/FrequencyView";
 import { CorpusDetail } from "@/components/analyses/CorpusDetail";
 import { SettingsView } from "@/components/analyses/SettingsView";
@@ -22,7 +24,7 @@ import { CommandPalette, type CommandDef } from "@/components/overlays/CommandPa
 import { BuildDialog } from "@/components/overlays/BuildDialog";
 import { CORPORA, RECENT_QUERIES, pickHits } from "@/data";
 import { makeDensity } from "@/lib/utils";
-import { inTauri, listCorpora, runCollocates, runKwic as runKwicTauri } from "@/lib/tauri";
+import { inTauri, isFixtureCorpus, listCorpora, runCollocates, runKwic as runKwicTauri } from "@/lib/tauri";
 import type { Collocate } from "@/types";
 import type {
   CorpusMeta,
@@ -111,73 +113,62 @@ export function App() {
   // counter drops stale responses so the freshest one wins. We don't
   // wipe `result` on refetch — the stale table stays visible so the
   // UI doesn't strobe on every keystroke.
+  // One fetch path for the concordance, keyed on (corpus, term, layer).
+  // A request-id guard drops superseded responses, so a real corpus can
+  // never end up showing a previous (fixture) corpus's stale hits.
   const kwicReqRef = useRef(0);
-  const runKwic = () => {
-    if (!activeCorpus || !term.trim()) return;
-    const myId = ++kwicReqRef.current;
-    setLoading(true);
-    const isRealCorpus = inTauri() && !CORPORA.some((c) => c.id === activeCorpus.id);
-    if (isRealCorpus) {
-      runKwicTauri({
-        corpusId: activeCorpus.id,
-        term: term.trim(),
-        layer,
-        context: 8,
-        limit: 200,
-      })
-        .then((r) => {
-          if (myId !== kwicReqRef.current) return;
-          // The Tauri backend returns hits with a numeric doc_id +
-          // file path; the frontend's KwicHit shape carries docId
-          // (string) and no path. Adapt the shape inline until the
-          // types converge.
-          const hits: KwicHit[] = r.hits.map((h, i) => ({
-            docId: String(h.docId),
-            pos: i,
-            hitPos: h.hitPosition,
-            left: h.left,
-            hit: h.hit,
-            right: h.right,
-          }));
-          setResult({ hits, elapsedMs: r.elapsedMs, truncated: r.truncated });
-          setSelected(null);
-        })
-        .catch((e) => {
-          console.error("runKwic failed:", e);
-          if (myId === kwicReqRef.current) {
-            setResult({ hits: [], elapsedMs: 0, truncated: false });
-            setSelected(null);
-          }
-        })
-        .finally(() => {
-          if (myId === kwicReqRef.current) setLoading(false);
-        });
+  const fetchKwic = useCallback((corpus: CorpusMeta | null, q: string, lyr: QueryLayer) => {
+    if (!corpus || !q.trim()) {
+      setResult(null);
+      setLoading(false);
       return;
     }
-    // Fallback: fixture data for the non-Tauri / pre-built-corpus case.
-    window.setTimeout(() => {
-      if (myId !== kwicReqRef.current) return;
-      const hits = pickHits(activeCorpus.id, term.trim(), layer);
-      const elapsedMs = 0.2 + Math.random() * 1.6;
-      setResult({ hits, elapsedMs, truncated: hits.length >= 1000 });
-      setSelected(null);
-      setLoading(false);
-    }, 40);
-  };
-  // Explicit Enter-key / "Run" button handler. Same path as the
-  // effects — the request-id guard handles any overlap.
-  const run = runKwic;
+    const myId = ++kwicReqRef.current;
+    setLoading(true);
+    // Fixture corpora (or non-Tauri preview) use the baked-in demo hits.
+    if (!inTauri() || isFixtureCorpus(corpus.id)) {
+      const hits = pickHits(corpus.id, q.trim(), lyr);
+      if (myId === kwicReqRef.current) {
+        setResult({ hits, elapsedMs: 0.2 + Math.random() * 1.6, truncated: hits.length >= 1000 });
+        setSelected(null);
+        setLoading(false);
+      }
+      return;
+    }
+    runKwicTauri({ corpusId: corpus.id, term: q.trim(), layer: lyr, context: 8, limit: 200 })
+      .then((r) => {
+        if (myId !== kwicReqRef.current) return;
+        const hits: KwicHit[] = r.hits.map((h, i) => ({
+          docId: String(h.docId),
+          pos: i,
+          hitPos: h.hitPosition,
+          left: h.left,
+          hit: h.hit,
+          right: h.right,
+        }));
+        setResult({ hits, elapsedMs: r.elapsedMs, truncated: r.truncated });
+        setSelected(null);
+      })
+      .catch((e) => {
+        if (myId !== kwicReqRef.current) return;
+        console.error("runKwic failed:", e);
+        setResult({ hits: [], elapsedMs: 0, truncated: false });
+        setSelected(null);
+      })
+      .finally(() => {
+        if (myId === kwicReqRef.current) setLoading(false);
+      });
+  }, []);
 
+  // Auto-fetch on corpus / term / layer change (debounced so typing
+  // coalesces). The guard inside drops stale responses.
   useEffect(() => {
-    runKwic();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [layer, activeCorpus]);
-
-  useEffect(() => {
-    const t = window.setTimeout(runKwic, 100);
+    const t = window.setTimeout(() => fetchKwic(activeCorpus, term, layer), 100);
     return () => window.clearTimeout(t);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [term]);
+  }, [activeCorpus, term, layer, fetchKwic]);
+
+  // Explicit Enter / "Run" — fetch immediately, no debounce.
+  const run = () => fetchKwic(activeCorpus, term, layer);
 
   // Fetch real collocates when the Collocations view is active on a
   // real (backend-registered) corpus. Fixture corpora keep whatever
@@ -396,6 +387,7 @@ export function App() {
             <CollocationsView
               corpus={activeCorpus}
               term={term}
+              layer={layer}
               data={collocates}
               loading={collLoading}
               truncated={collTruncated}
@@ -409,6 +401,12 @@ export function App() {
           )}
           {subview === "freq" && activeCorpus && (
             <FrequencyView corpus={activeCorpus} term={term} />
+          )}
+          {subview === "tree" && activeCorpus && (
+            <WordTree corpusName={activeCorpus.name} term={term} result={result} loading={loading} />
+          )}
+          {subview === "dist" && activeCorpus && (
+            <CollocationDistance corpus={activeCorpus} term={term} layer={layer} />
           )}
         </div>
       </>

--- a/app/src/components/analyses/CollocationDistance.tsx
+++ b/app/src/components/analyses/CollocationDistance.tsx
@@ -1,0 +1,170 @@
+// Collocation-by-distance — a heatmap of where each collocate sits
+// relative to the node. Rows are the busiest collocates, columns are the
+// slot offsets (−5 … −1 │ node │ +1 … +5); cell intensity = how often the
+// word lands at that distance. Reveals positional preference at a glance:
+// e.g. `freeze` lighting up at −1, `assets` at +1.
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  type DistanceRow,
+  hasLiveData,
+  runCollocateDistance,
+} from "@/lib/tauri";
+import type { CorpusMeta, QueryLayer } from "@/types";
+
+export interface CollocationDistanceProps {
+  corpus: CorpusMeta;
+  term: string;
+  layer: QueryLayer;
+}
+
+const WINDOW = 5;
+const LIMIT = 25;
+
+export function CollocationDistance({ corpus, term, layer }: CollocationDistanceProps) {
+  const isLive = hasLiveData(corpus.id);
+  const [offsets, setOffsets] = useState<number[] | null>(null);
+  const [rows, setRows] = useState<DistanceRow[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setRows(null);
+    setOffsets(null);
+    if (!isLive || !term.trim()) return;
+    let cancelled = false;
+    setLoading(true);
+    runCollocateDistance({
+      corpusId: corpus.id,
+      term: term.trim(),
+      layer,
+      leftWindow: WINDOW,
+      rightWindow: WINDOW,
+      limit: LIMIT,
+    })
+      .then((r) => {
+        if (cancelled) return;
+        setOffsets(r.offsets);
+        setRows(r.rows);
+      })
+      .catch((e) => {
+        console.error("runCollocateDistance failed:", e);
+        if (!cancelled) {
+          setOffsets([]);
+          setRows([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [corpus.id, term, layer, isLive]);
+
+  const maxCount = useMemo(
+    () => Math.max(1, ...(rows ?? []).flatMap((r) => r.counts)),
+    [rows],
+  );
+
+  // Columns: left offsets, the node, then right offsets.
+  const cols = useMemo(() => {
+    const os = offsets ?? [];
+    const left = os.filter((o) => o < 0);
+    const right = os.filter((o) => o > 0);
+    return { left, right };
+  }, [offsets]);
+
+  const cell = (count: number) => {
+    const pct = (count / maxCount) * 100;
+    return {
+      background: count === 0 ? "transparent" : `color-mix(in oklch, var(--accent) ${Math.max(8, pct)}%, transparent)`,
+    };
+  };
+
+  const empty = !loading && isLive && rows != null && rows.length === 0;
+
+  return (
+    <div className="cx-coll-wrap">
+      <div className="cx-coll-main">
+        <div className="cx-coll-head">
+          <h2 className="cx-coll-title">
+            distance profile · <span className="kw">{term}</span>{" "}
+            <span style={{ color: "var(--fg-muted)", fontSize: 14 }}>· {corpus.name}</span>
+          </h2>
+          <div className="cx-coll-controls">
+            <span>±{WINDOW} tokens · top {LIMIT}</span>
+          </div>
+        </div>
+
+        <div className="cx-coll-graph" style={{ overflow: "auto", height: "clamp(460px, 60vh, 780px)", padding: 16 }}>
+          {!isLive ? (
+            <div className="cx-dist-msg">distance profiles are computed on built corpora</div>
+          ) : loading ? (
+            <div className="cx-loading-row" style={{ justifyContent: "center", height: "100%" }}>
+              <span className="cx-spinner" /> computing distances…
+            </div>
+          ) : empty ? (
+            <div className="cx-dist-msg">
+              {layer === "pos"
+                ? `no matches for “${term}” on the POS layer — search a tag (NN, VB, JJ…)`
+                : `no collocates for “${term}” on this layer`}
+            </div>
+          ) : rows && offsets ? (
+            <table className="cx-dist-table">
+              <thead>
+                <tr>
+                  <th className="cx-dist-word" />
+                  {cols.left.map((o) => (
+                    <th key={o} className="cx-dist-col">
+                      {o}
+                    </th>
+                  ))}
+                  <th className="cx-dist-node">{term}</th>
+                  {cols.right.map((o) => (
+                    <th key={o} className="cx-dist-col">
+                      +{o}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.word}>
+                    <td className="cx-dist-word">
+                      {r.word} <span className="cx-dist-total">{r.total}</span>
+                    </td>
+                    {cols.left.map((o) => {
+                      const i = offsets.indexOf(o);
+                      const c = r.counts[i] ?? 0;
+                      return (
+                        <td key={o} className="cx-dist-cell" style={cell(c)} title={`${r.word} at ${o}: ${c}`}>
+                          {c > 0 ? c : ""}
+                        </td>
+                      );
+                    })}
+                    <td className="cx-dist-nodecell" />
+                    {cols.right.map((o) => {
+                      const i = offsets.indexOf(o);
+                      const c = r.counts[i] ?? 0;
+                      return (
+                        <td key={o} className="cx-dist-cell" style={cell(c)} title={`${r.word} at +${o}: ${c}`}>
+                          {c > 0 ? c : ""}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : null}
+        </div>
+
+        <div className="cx-coll-legend">
+          <span className="cx-coll-leg-note">
+            ← left of node · right of node → · cell shade ∝ count at that slot
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/analyses/CollocationsView.tsx
+++ b/app/src/components/analyses/CollocationsView.tsx
@@ -1,22 +1,23 @@
-// Collocation scatter — a proper SVG chart.
+// Collocation visualisation — three swappable views over the same data,
+// chosen with the "view" selector so the modes can be compared fairly.
+// All three share the same pan/zoom canvas (scroll = zoom, drag = pan,
+// "fit" button = centre on content, slider = zoom level):
 //
-// Semantics
-//   x = left/right preference ratio: (rightCount − leftCount) / total.
-//       −1 = purely pre-node, 0 = balanced, +1 = purely post-node.
-//       The node itself sits at x=0 (dashed amber axis).
-//   y = association score (logDice | MI | z-score), user-selectable.
-//   radius = sqrt(total frequency) — bigger dot = more occurrences.
-//   color = POS family (noun amber / verb teal / adj violet / adv gold /
-//           function grey).
+//   network   — GraphColl-style radial graph. Node at centre; collocates
+//               radiate out, angle = left/right preference, distance =
+//               association strength (closer = stronger). A collision
+//               relaxation keeps the word labels from overlapping — the
+//               thing that makes a dense scatter unreadable.
+//   scatter   — x = left/right preference, y = score (axis auto-fit to the
+//               data band). Greedy label declutter.
+//   declutter — the same scatter, labelling only the strongest few +
+//               whatever's hovered. Clean at a glance.
 //
-// A pure-SVG scatter beats absolute-positioned divs because the chart
-// becomes visually legible — scale, gridlines, hit-state highlighting,
-// smooth metric transitions. All handled with stdlib + a little math;
-// no d3 runtime in the bundle.
+// All pure SVG + stdlib math; no d3 in the bundle.
 
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { COLLOCATIONS } from "@/data";
-import type { CollMetric, Collocate, CorpusMeta } from "@/types";
+import type { CollMetric, Collocate, CorpusMeta, QueryLayer } from "@/types";
 
 const POS_FAMILY_COLOR = {
   noun: "var(--layer-word)",
@@ -36,48 +37,97 @@ function posFamily(tag: string): PosFamily {
   return "function";
 }
 
+const colorOf = (pos: string) => POS_FAMILY_COLOR[posFamily(pos)];
+
 function prefRatio(c: Collocate): number {
   if (c.total === 0) return 0;
   return (c.rightCount - c.leftCount) / c.total;
 }
 
-// Evenly spaced "nice" ticks across a signed domain, always landing a
-// tick on zero (start is floored to a step multiple, and zero is a
-// multiple of any step).
-function signedTicks(min: number, max: number, count = 5): number[] {
+const rFor = (total: number, maxTotal: number) =>
+  4 + (Math.sqrt(total) / Math.sqrt(Math.max(1, maxTotal))) * 11;
+
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+// Word labels render in the sans face (Inter) — it has clean glyphs for
+// the diacritics / ligatures (æ, œ, …) that show up in real corpus words
+// and that a monospace face mangles. Because sans is proportional, label
+// widths are measured exactly via a canvas so the collision layout stays
+// tight instead of guessing from character count.
+const LABEL_FONT = '12px "Inter", system-ui, sans-serif';
+const NODE_FONT = '600 14px "Inter", system-ui, sans-serif';
+let _measureCtx: CanvasRenderingContext2D | null = null;
+function measureWidth(text: string, font: string): number {
+  if (typeof document === "undefined") return text.length * 7;
+  if (!_measureCtx) _measureCtx = document.createElement("canvas").getContext("2d");
+  if (!_measureCtx) return text.length * 7;
+  _measureCtx.font = font;
+  return _measureCtx.measureText(text).width;
+}
+
+/** Fit a value axis to the data's actual range (plus padding) rather than
+ *  anchoring at zero — logDice clusters in a narrow high band, so a
+ *  0-based axis wastes most of the canvas. */
+function fitDomain(values: number[]): [number, number] {
+  if (values.length === 0) return [0, 1];
+  let lo = Math.min(...values);
+  let hi = Math.max(...values);
+  if (lo === hi) {
+    lo -= 1;
+    hi += 1;
+  }
+  const pad = (hi - lo) * 0.08;
+  return [lo - pad, hi + pad];
+}
+
+/** Evenly spaced "nice" ticks across a signed domain. */
+function axisTicks(min: number, max: number, count = 5): number[] {
   const span = max - min || 1;
   const rawStep = span / (count - 1);
   const pow = Math.pow(10, Math.floor(Math.log10(rawStep)));
   const step = Math.ceil(rawStep / pow) * pow || 1;
-  const start = Math.floor(min / step) * step;
+  const start = Math.ceil(min / step) * step;
   const ticks: number[] = [];
-  for (let v = start; v <= max + step * 0.5; v += step) {
+  for (let v = start; v <= max + step * 0.001; v += step) {
     ticks.push(Number(v.toFixed(6)));
   }
   return ticks;
 }
 
-const W = 760;
-const H = 380;
-const M = { top: 28, right: 32, bottom: 56, left: 56 };
+const fmtTick = (t: number) => (Math.abs(t) >= 10 ? t.toFixed(0) : t.toFixed(1));
+
+const W = 820;
+const H = 460;
+const M = { top: 28, right: 36, bottom: 52, left: 56 };
 const PW = W - M.left - M.right;
 const PH = H - M.top - M.bottom;
+const ZOOM_MIN = 0.4;
+const ZOOM_MAX = 16;
+
+interface Bounds {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+type VizMode = "network" | "scatter";
 
 export interface CollocationsViewProps {
   corpus: CorpusMeta | null;
   term: string;
+  /** Active query layer — lets the empty state explain that the POS layer
+   *  expects a tag (NN, VB, …) rather than a word. */
+  layer?: QueryLayer;
   /** Real collocates from the backend. When null, falls back to the
    *  fixture `COLLOCATIONS` so the view still looks populated in
    *  demos / non-Tauri preview. */
   data?: Collocate[] | null;
-  /** Backend scan in flight — show a loading overlay. The full-corpus
-   *  scan can take a moment on a frequent node. */
+  /** Backend scan in flight — show a loading overlay. */
   loading?: boolean;
-  /** The scan hit its safety ceiling; scores are from a large sample,
-   *  not every occurrence. Surface it rather than silently capping. */
+  /** The scan hit its safety ceiling; scores are from a large sample. */
   truncated?: boolean;
-  /** Tokens on the left of the node to consider (0 = skip). Lifted
-   *  to App so the backend refetch uses the same values the UI shows. */
+  /** Tokens on the left of the node to consider (0 = skip). */
   leftWindow?: number;
   rightWindow?: number;
   onWindowChange?: (left: number, right: number) => void;
@@ -89,6 +139,7 @@ type CollSortKey = "word" | "pos" | "leftCount" | "rightCount" | "total" | "logD
 
 export function CollocationsView({
   term,
+  layer,
   data: dataProp,
   loading = false,
   truncated = false,
@@ -97,6 +148,8 @@ export function CollocationsView({
   onWindowChange,
 }: CollocationsViewProps) {
   const [metric, setMetric] = useState<CollMetric>("logDice");
+  const [vizMode, setVizMode] = useState<VizMode>("network");
+  const [declutter, setDeclutter] = useState(false);
   const [hover, setHover] = useState<string | null>(null);
   const [sortKey, setSortKey] = useState<CollSortKey>("total");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
@@ -110,11 +163,19 @@ export function CollocationsView({
     }
   };
 
-  const rawData = useMemo(
-    () => (dataProp && dataProp.length > 0 ? dataProp : COLLOCATIONS),
-    [dataProp],
-  );
-  const data = useMemo(() => {
+  // `dataProp` is null only for fixture/demo corpora (App never queried the
+  // backend); a live corpus always passes an array — possibly empty. Don't
+  // fall back to the demo fixture for a live empty result (that showed the
+  // coloured demo collocates and looked like a real, colourful answer).
+  const isLiveData = dataProp != null;
+  const rawData = useMemo(() => (isLiveData ? dataProp : COLLOCATIONS), [dataProp, isLiveData]);
+  const isEmptyLive = isLiveData && rawData.length === 0;
+
+  // The chart uses a stable order (by total, frequency) independent of the
+  // table's sort — sorting the table below must not reshuffle the graph.
+  const chartData = useMemo(() => [...rawData].sort((a, b) => b.total - a.total), [rawData]);
+  // The table gets its own sort.
+  const tableData = useMemo(() => {
     const copy = [...rawData];
     copy.sort((a, b) => {
       const av = a[sortKey] as unknown as number | string;
@@ -125,30 +186,25 @@ export function CollocationsView({
     if (sortDir === "desc") copy.reverse();
     return copy;
   }, [rawData, sortKey, sortDir]);
-  // y-axis domain always straddles zero: MI and z-score go negative for
-  // dispreferred collocates, so the axis can't assume a 0-based range.
-  const [domMin, domMax] = useMemo(() => {
-    const scores = data.map((d) => d[metric]);
-    const lo = Math.min(0, ...scores);
-    const hi = Math.max(0, ...scores);
-    const pad = (hi - lo) * 0.05 || 1;
-    return [lo - (lo < 0 ? pad : 0), hi + pad];
-  }, [data, metric]);
-  const maxTotal = useMemo(() => Math.max(1, ...data.map((d) => d.total)), [data]);
 
-  const xFor = (pref: number) => M.left + ((pref + 1) / 2) * PW;
-  const yFor = (score: number) =>
-    M.top + PH - ((score - domMin) / (domMax - domMin || 1)) * PH;
-  const rFor = (total: number) => 4 + (Math.sqrt(total) / Math.sqrt(maxTotal)) * 12;
-  const colorOf = (pos: string) => POS_FAMILY_COLOR[posFamily(pos)];
-  // Strength meter: collocate's position within the signed domain (so a
-  // strongly negative score reads as a short bar, not a clamped stub).
+  const [domMin, domMax] = useMemo(() => fitDomain(rawData.map((d) => d[metric])), [rawData, metric]);
+  const maxTotal = useMemo(() => Math.max(1, ...rawData.map((d) => d.total)), [rawData]);
   const meterWidth = (score: number) =>
     Math.max(4, ((score - domMin) / (domMax - domMin || 1)) * 120);
 
-  const yTicks = signedTicks(domMin, domMax, 5);
-  const xTicks = [-1, -0.5, 0, 0.5, 1];
   const metricLabel = metric === "logDice" ? "log-Dice" : metric === "mi" ? "MI" : "z-score";
+
+  const chartProps: ChartProps = {
+    data: chartData,
+    metric,
+    term,
+    domMin,
+    domMax,
+    maxTotal,
+    hover,
+    setHover,
+    metricLabel,
+  };
 
   return (
     <div className="cx-coll-wrap">
@@ -174,7 +230,37 @@ export function CollocationsView({
             )}
           </h2>
           <div className="cx-coll-controls">
-            <span>L</span>
+            <span>view</span>
+            <div className="cx-coll-segbtn">
+              {(
+                [
+                  ["network", "network"],
+                  ["scatter", "scatter"],
+                ] as const
+              ).map(([k, l]) => (
+                <button
+                  key={k}
+                  type="button"
+                  className={vizMode === k ? "is-on" : ""}
+                  onClick={() => setVizMode(k)}
+                >
+                  {l}
+                </button>
+              ))}
+            </div>
+            {vizMode === "scatter" && (
+              <div className="cx-coll-segbtn">
+                <button
+                  type="button"
+                  className={declutter ? "is-on" : ""}
+                  onClick={() => setDeclutter((d) => !d)}
+                  title="thin to the strongest labels and hide clashes"
+                >
+                  declutter
+                </button>
+              </div>
+            )}
+            <span style={{ marginLeft: 12 }}>L</span>
             <div className="cx-coll-segbtn">
               {WINDOW_CHOICES.map((w) => (
                 <button
@@ -227,7 +313,10 @@ export function CollocationsView({
         </div>
 
         <div className="cx-coll-graph cx-coll-svg-wrap" style={{ position: "relative" }}>
-          {loading && (
+          {loading ? (
+            // While a query runs, render *only* the overlay — never the
+            // chart with stale data, which would mount with the wrong
+            // bounds and then re-fit (the "huge centre node, then jump").
             <div
               style={{
                 position: "absolute",
@@ -235,215 +324,39 @@ export function CollocationsView({
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                background: "color-mix(in oklch, var(--bg) 55%, transparent)",
-                backdropFilter: "blur(1px)",
-                zIndex: 2,
                 fontFamily: "var(--font-mono)",
                 fontSize: 12,
                 color: "var(--fg-muted)",
                 letterSpacing: "0.04em",
-                transition: "opacity var(--dur-2) var(--ease)",
               }}
             >
               computing collocations…
             </div>
+          ) : isEmptyLive ? (
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontFamily: "var(--font-mono)",
+                fontSize: 12,
+                color: "var(--fg-subtle)",
+                letterSpacing: "0.03em",
+                textAlign: "center",
+                padding: 24,
+              }}
+            >
+              {layer === "pos"
+                ? `no matches for “${term}” on the POS layer — search a tag (NN, VB, JJ…)`
+                : `no collocates for “${term}” on this layer`}
+            </div>
+          ) : vizMode === "network" ? (
+            <NetworkChart {...chartProps} />
+          ) : (
+            <ScatterChart {...chartProps} labelMode={declutter ? "topN" : "all"} />
           )}
-          <svg
-            viewBox={`0 0 ${W} ${H}`}
-            preserveAspectRatio="xMidYMid meet"
-            style={{ width: "100%", height: "100%", display: "block" }}
-          >
-            {/* Y gridlines + labels */}
-            {yTicks.map((t) => (
-              <g key={`y-${t}`}>
-                <line
-                  x1={M.left}
-                  x2={W - M.right}
-                  y1={yFor(t)}
-                  y2={yFor(t)}
-                  stroke="var(--border)"
-                  strokeWidth={1}
-                  opacity={t === 0 ? 0.6 : 0.35}
-                />
-                <text
-                  x={M.left - 10}
-                  y={yFor(t)}
-                  textAnchor="end"
-                  dominantBaseline="middle"
-                  style={{ fontFamily: "var(--font-mono)", fontSize: 10, fill: "var(--fg-subtle)" }}
-                >
-                  {t.toFixed(t > 1 ? 0 : 1)}
-                </text>
-              </g>
-            ))}
-
-            {/* Y axis title */}
-            <text
-              x={18}
-              y={M.top + PH / 2}
-              textAnchor="middle"
-              dominantBaseline="middle"
-              transform={`rotate(-90 18 ${M.top + PH / 2})`}
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: 10,
-                fill: "var(--fg-subtle)",
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-              }}
-            >
-              {metricLabel}
-            </text>
-
-            {/* Vertical center (node) line */}
-            <line
-              x1={xFor(0)}
-              x2={xFor(0)}
-              y1={M.top - 4}
-              y2={H - M.bottom + 4}
-              stroke="var(--accent)"
-              strokeWidth={1}
-              strokeDasharray="3 4"
-              opacity={0.4}
-            />
-
-            {/* X axis baseline + ticks */}
-            <line
-              x1={M.left}
-              x2={W - M.right}
-              y1={H - M.bottom}
-              y2={H - M.bottom}
-              stroke="var(--border)"
-            />
-            {xTicks.map((t) => (
-              <g key={`x-${t}`}>
-                <line
-                  x1={xFor(t)}
-                  x2={xFor(t)}
-                  y1={H - M.bottom}
-                  y2={H - M.bottom + 4}
-                  stroke="var(--border)"
-                />
-                <text
-                  x={xFor(t)}
-                  y={H - M.bottom + 18}
-                  textAnchor="middle"
-                  style={{ fontFamily: "var(--font-mono)", fontSize: 10, fill: "var(--fg-subtle)" }}
-                >
-                  {t === 0 ? "" : t > 0 ? `+${t}` : `${t}`}
-                </text>
-              </g>
-            ))}
-
-            {/* Axis side labels */}
-            <text
-              x={M.left}
-              y={H - 8}
-              textAnchor="start"
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: 10,
-                fill: "var(--fg-subtle)",
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-              }}
-            >
-              ← left of node
-            </text>
-            <text
-              x={W - M.right}
-              y={H - 8}
-              textAnchor="end"
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: 10,
-                fill: "var(--fg-subtle)",
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-              }}
-            >
-              right of node →
-            </text>
-
-            {/* Node label at x=0 above the plot */}
-            <text
-              x={xFor(0)}
-              y={M.top - 10}
-              textAnchor="middle"
-              style={{
-                fontFamily: "var(--font-mono)",
-                fontSize: 11,
-                fill: "var(--accent)",
-                fontWeight: 600,
-                letterSpacing: "0.02em",
-              }}
-            >
-              {term}
-            </text>
-
-            {/* Data points */}
-            {data.map((c) => {
-              const cx = xFor(prefRatio(c));
-              const cy = yFor(c[metric]);
-              const r = rFor(c.total);
-              const color = colorOf(c.pos);
-              const labelRight = prefRatio(c) <= 0;
-              const isHover = hover === c.word;
-              const dimmed = hover !== null && !isHover;
-              return (
-                <g
-                  key={c.word}
-                  transform={`translate(${cx}, ${cy})`}
-                  style={{
-                    cursor: "pointer",
-                    transition: "transform 280ms cubic-bezier(.4,.0,.2,1), opacity 180ms",
-                    opacity: dimmed ? 0.28 : 1,
-                  }}
-                  onMouseEnter={() => setHover(c.word)}
-                  onMouseLeave={() => setHover(null)}
-                >
-                  <circle
-                    r={r}
-                    fill={color}
-                    fillOpacity={isHover ? 0.42 : 0.22}
-                    stroke={color}
-                    strokeWidth={isHover ? 2 : 1.2}
-                    style={{ transition: "r 220ms ease, fill-opacity 180ms, stroke-width 180ms" }}
-                  />
-                  <text
-                    x={labelRight ? r + 6 : -(r + 6)}
-                    y={4}
-                    textAnchor={labelRight ? "start" : "end"}
-                    style={{
-                      fontFamily: "var(--font-mono)",
-                      fontSize: isHover ? 13 : 12,
-                      fill: "var(--fg)",
-                      fontWeight: isHover ? 600 : 400,
-                      pointerEvents: "none",
-                      transition: "font-size 160ms",
-                    }}
-                  >
-                    {c.word}
-                  </text>
-                  {isHover && (
-                    <g transform={`translate(${labelRight ? r + 6 : -(r + 6)}, 18)`}>
-                      <text
-                        textAnchor={labelRight ? "start" : "end"}
-                        style={{
-                          fontFamily: "var(--font-mono)",
-                          fontSize: 10,
-                          fill: "var(--fg-muted)",
-                          pointerEvents: "none",
-                        }}
-                      >
-                        {c.pos} · {metricLabel} {c[metric].toFixed(1)} · {c.total.toLocaleString()}×
-                      </text>
-                    </g>
-                  )}
-                </g>
-              );
-            })}
-          </svg>
         </div>
 
         <div className="cx-coll-legend">
@@ -462,7 +375,9 @@ export function CollocationsView({
             </span>
           ))}
           <span className="cx-coll-leg-sep">·</span>
-          <span className="cx-coll-leg-note">dot size ∝ total frequency</span>
+          <span className="cx-coll-leg-note">
+            scroll = zoom · drag = pan · ⤢ = centre · dot size ∝ frequency
+          </span>
         </div>
 
         <table className="cx-coll-table">
@@ -480,7 +395,7 @@ export function CollocationsView({
             </tr>
           </thead>
           <tbody>
-            {data.map((c) => (
+            {tableData.map((c) => (
               <tr
                 key={c.word}
                 onMouseEnter={() => setHover(c.word)}
@@ -506,6 +421,635 @@ export function CollocationsView({
         </table>
       </div>
     </div>
+  );
+}
+
+interface ChartProps {
+  data: Collocate[];
+  metric: CollMetric;
+  term: string;
+  domMin: number;
+  domMax: number;
+  maxTotal: number;
+  hover: string | null;
+  setHover: (w: string | null) => void;
+  metricLabel: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared pan/zoom canvas
+// ---------------------------------------------------------------------------
+
+/** Transform that fits content `bounds` (base coords) into the viewport. */
+function fitTransform(b: Bounds): { k: number; tx: number; ty: number } {
+  const k = clamp(Math.min(W / b.w, H / b.h) * 0.92, ZOOM_MIN, ZOOM_MAX);
+  return { k, tx: W / 2 - k * (b.x + b.w / 2), ty: H / 2 - k * (b.y + b.h / 2) };
+}
+
+/** SVG with scroll-to-zoom, drag-to-pan, a "fit" button and a zoom
+ *  slider. Children are drawn in base [0..W]×[0..H] coords; the transform
+ *  scales the whole picture uniformly (so labels/dots/grid stay aligned).
+ *  `bounds` is the content extent in base coords, used by the fit control;
+ *  `autoFit` fits once when the bounds change (used by the network layout,
+ *  whose extent varies). */
+function ZoomPanSvg({
+  bounds,
+  autoFit,
+  children,
+  onLeave,
+}: {
+  bounds: Bounds;
+  autoFit: boolean;
+  children: React.ReactNode;
+  /** Called when the pointer leaves the chart — used to clear any stuck
+   *  hover (a node raised-to-front can otherwise miss its mouseleave). */
+  onLeave?: () => void;
+}) {
+  // Initialise already-fitted (when autoFit) so the first paint is the
+  // centred view — no identity frame where the centre node renders huge
+  // before the fit effect kicks in.
+  const [t, setT] = useState(() => (autoFit ? fitTransform(bounds) : { k: 1, tx: 0, ty: 0 }));
+  const tRef = useRef(t);
+  tRef.current = t;
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const drag = useRef<{ cx: number; cy: number; tx: number; ty: number } | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  const fitTo = useCallback((b: Bounds) => setT(fitTransform(b)), []);
+
+  // Re-fit when the content extent changes (e.g. a new query while the
+  // network view is already open). The initial fit is handled by the
+  // lazy state above, so this only matters for subsequent bounds changes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (autoFit) fitTo(bounds);
+  }, [autoFit, bounds.x, bounds.y, bounds.w, bounds.h]);
+
+  // Non-passive wheel listener on the wrapper so zooming never scrolls the
+  // page, even over the chart's letterboxed margins.
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = el.getBoundingClientRect();
+      const sx = ((e.clientX - rect.left) / rect.width) * W;
+      const sy = ((e.clientY - rect.top) / rect.height) * H;
+      const cur = tRef.current;
+      const k = clamp(cur.k * Math.exp(-e.deltaY * 0.0012), ZOOM_MIN, ZOOM_MAX);
+      const ratio = k / cur.k;
+      setT({ k, tx: sx - (sx - cur.tx) * ratio, ty: sy - (sy - cur.ty) * ratio });
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, []);
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault(); // don't start a text selection while panning
+    drag.current = { cx: e.clientX, cy: e.clientY, tx: t.tx, ty: t.ty };
+    setDragging(true);
+    onLeave?.(); // dropping into a pan shouldn't leave a node stuck-hovered
+  };
+  const onMouseMove = (e: React.MouseEvent) => {
+    const d = drag.current;
+    const el = wrapRef.current;
+    if (!d || !el) return;
+    const rect = el.getBoundingClientRect();
+    const dx = ((e.clientX - d.cx) / rect.width) * W;
+    const dy = ((e.clientY - d.cy) / rect.height) * H;
+    setT((cur) => ({ ...cur, tx: d.tx + dx, ty: d.ty + dy }));
+  };
+  const endDrag = () => {
+    drag.current = null;
+    setDragging(false);
+  };
+
+  const setZoom = (level: number) => {
+    setT((cur) => {
+      const ratio = level / cur.k;
+      return { k: level, tx: W / 2 - (W / 2 - cur.tx) * ratio, ty: H / 2 - (H / 2 - cur.ty) * ratio };
+    });
+  };
+
+  return (
+    <div ref={wrapRef} style={{ position: "absolute", inset: 0, userSelect: "none", WebkitUserSelect: "none" }}>
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="xMidYMid meet"
+        style={{ width: "100%", height: "100%", display: "block", cursor: dragging ? "grabbing" : "grab", userSelect: "none", WebkitUserSelect: "none" }}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={endDrag}
+        onMouseLeave={() => {
+          endDrag();
+          onLeave?.();
+        }}
+        onDoubleClick={() => fitTo(bounds)}
+      >
+        <g transform={`translate(${t.tx} ${t.ty}) scale(${t.k})`}>{children}</g>
+      </svg>
+
+      {/* controls */}
+      <div
+        style={{
+          position: "absolute",
+          top: 10,
+          right: 10,
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "4px 8px",
+          background: "color-mix(in oklch, var(--bg-raised) 88%, transparent)",
+          border: "1px solid var(--border)",
+          borderRadius: 6,
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => fitTo(bounds)}
+          title="centre on content"
+          style={{
+            border: 0,
+            background: "transparent",
+            color: "var(--fg-muted)",
+            cursor: "pointer",
+            fontSize: 14,
+            lineHeight: 1,
+            padding: 0,
+          }}
+        >
+          ⤢
+        </button>
+        <input
+          type="range"
+          min={ZOOM_MIN}
+          max={ZOOM_MAX}
+          step={0.01}
+          value={t.k}
+          onChange={(e) => setZoom(Number(e.target.value))}
+          title={`zoom ${t.k.toFixed(1)}×`}
+          style={{ width: 96, accentColor: "var(--accent)" }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Network (GraphColl-style radial graph)
+// ---------------------------------------------------------------------------
+
+function NetworkChart({ data, metric, term, domMin, domMax, maxTotal, hover, setHover, metricLabel }: ChartProps) {
+  const { cx0, cy0, nodes, bounds, nodeR } = useMemo(() => {
+    const cx0 = W / 2;
+    const cy0 = H / 2;
+    // Centre node is a circle big enough to hold the full term.
+    const nodeR = clamp(measureWidth(term, NODE_FONT) / 2 + 16, 30, 150);
+    const minR = Math.max(86, nodeR + 34);
+    const maxR = Math.min(W, H) / 2 - 26;
+    const span = domMax - domMin || 1;
+
+    // Even radial spread: distance encodes strength (strong → near the
+    // node), angle is an even golden-angle distribution around the full
+    // circle. The collision pass below settles overlaps.
+    const GOLDEN = Math.PI * (3 - Math.sqrt(5));
+    const nodes = data.map((c, i) => {
+      const t = clamp((c[metric] - domMin) / span, 0, 1); // 1 = strongest
+      const radius = maxR - t * (maxR - minR); // strong → close to node
+      const angle = i * GOLDEN;
+      return {
+        c,
+        x: cx0 + radius * Math.cos(angle),
+        y: cy0 - radius * Math.sin(angle),
+        w: measureWidth(c.word, LABEL_FONT) + 16,
+        h: 16,
+      };
+    });
+
+    // Collision relaxation: push overlapping label boxes apart, keep them
+    // clear of the node chip and inside the canvas. Deterministic.
+    for (let iter = 0; iter < 160; iter++) {
+      for (let i = 0; i < nodes.length; i++) {
+        for (let j = i + 1; j < nodes.length; j++) {
+          const a = nodes[i];
+          const b = nodes[j];
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          const ox = (a.w + b.w) / 2 - Math.abs(dx);
+          const oy = (a.h + b.h) / 2 + 3 - Math.abs(dy);
+          if (ox > 0 && oy > 0) {
+            if (ox < oy) {
+              const m = (ox / 2) * (dx >= 0 ? 1 : -1);
+              a.x -= m;
+              b.x += m;
+            } else {
+              const m = (oy / 2) * (dy >= 0 ? 1 : -1);
+              a.y -= m;
+              b.y += m;
+            }
+          }
+        }
+      }
+      for (const n of nodes) {
+        const dx = n.x - cx0;
+        const dy = n.y - cy0;
+        const dist = Math.hypot(dx, dy) || 1;
+        if (dist < minR) {
+          n.x = cx0 + (dx / dist) * minR;
+          n.y = cy0 + (dy / dist) * minR;
+        }
+      }
+    }
+
+    // Content extent (include label widths) for the fit control.
+    let x0 = cx0;
+    let y0 = cy0;
+    let x1 = cx0;
+    let y1 = cy0;
+    for (const n of nodes) {
+      x0 = Math.min(x0, n.x - n.w / 2);
+      x1 = Math.max(x1, n.x + n.w / 2);
+      y0 = Math.min(y0, n.y - 10);
+      y1 = Math.max(y1, n.y + 10);
+    }
+    const pad = 20;
+    const bounds: Bounds = { x: x0 - pad, y: y0 - pad, w: x1 - x0 + 2 * pad, h: y1 - y0 + 2 * pad };
+    return { cx0, cy0, nodes, bounds, nodeR };
+  }, [data, metric, domMin, domMax, term]);
+
+  // Draw the hovered node last so it sits above its neighbours (the
+  // labels are scattered, not stacked, so the active one must come to
+  // front to read clearly).
+  const ordered = hover ? [...nodes].sort((a, b) => (a.c.word === hover ? 1 : b.c.word === hover ? -1 : 0)) : nodes;
+
+  return (
+    <ZoomPanSvg bounds={bounds} autoFit onLeave={() => setHover(null)}>
+      {/* edges */}
+      {nodes.map((n) => {
+        const isHover = hover === n.c.word;
+        const dimmed = hover !== null && !isHover;
+        return (
+          <line
+            key={`e-${n.c.word}`}
+            x1={cx0}
+            y1={cy0}
+            x2={n.x}
+            y2={n.y}
+            stroke={isHover ? colorOf(n.c.pos) : "var(--border)"}
+            strokeWidth={isHover ? 1.5 : 1}
+            opacity={dimmed ? 0.12 : isHover ? 0.7 : 0.3}
+          />
+        );
+      })}
+
+      {/* node centre — a circle big enough for the full term */}
+      <circle cx={cx0} cy={cy0} r={nodeR} fill="var(--bg)" stroke="var(--accent)" strokeWidth={1.5} />
+      <text x={cx0} y={cy0 + 5} textAnchor="middle" style={{ fontFamily: "var(--font-sans)", fontSize: 14, fontWeight: 600, fill: "var(--accent)" }}>
+        {term}
+      </text>
+
+      {/* collocates */}
+      {ordered.map((n) => {
+        const c = n.c;
+        const isHover = hover === c.word;
+        const dimmed = hover !== null && !isHover;
+        const color = colorOf(c.pos);
+        const labelW = measureWidth(c.word, LABEL_FONT);
+        const dot = rFor(c.total, maxTotal);
+        const half = Math.max(labelW / 2, dot);
+        return (
+          <g
+            key={c.word}
+            transform={`translate(${n.x}, ${n.y})`}
+            style={{ cursor: "pointer", opacity: dimmed ? 0.28 : 1 }}
+            onMouseEnter={() => setHover(c.word)}
+            onMouseLeave={() => setHover(null)}
+          >
+            {/* transparent hit area covering dot + label so hovering the
+                text (not just the dot) selects the node */}
+            <rect x={-half - 4} y={-12} width={2 * half + 8} height={24} fill="transparent" />
+            <circle
+              r={dot}
+              fill={color}
+              stroke={color}
+              pointerEvents="none"
+              style={{
+                fillOpacity: isHover ? 0.5 : 0.18,
+                strokeWidth: isHover ? 2 : 1,
+                transition: "fill-opacity 130ms var(--ease), stroke-width 130ms var(--ease)",
+              }}
+            />
+            <text
+              y={4}
+              textAnchor="middle"
+              style={{
+                fontFamily: "var(--font-sans)",
+                fontSize: 12,
+                fontWeight: 500,
+                fill: isHover ? "var(--accent)" : "var(--fg)",
+                pointerEvents: "none",
+                paintOrder: "stroke",
+                stroke: "var(--bg)",
+                strokeWidth: 4,
+                transition: "fill 130ms var(--ease)",
+              }}
+            >
+              {c.word}
+            </text>
+            {isHover &&
+              (() => {
+                const tip = `${metricLabel} ${c[metric].toFixed(1)} · ${c.total.toLocaleString()}×`;
+                const tw = measureWidth(tip, '10px "JetBrains Mono", monospace');
+                return (
+                  <g pointerEvents="none">
+                    {/* opaque backing so the readout stays legible over nodes behind it */}
+                    <rect x={-tw / 2 - 6} y={13} width={tw + 12} height={17} rx={4} fill="var(--bg)" fillOpacity={0.92} stroke="var(--border)" strokeWidth={1} />
+                    <text y={25} textAnchor="middle" style={{ fontFamily: "var(--font-mono)", fontSize: 10, fill: "var(--fg-muted)" }}>
+                      {tip}
+                    </text>
+                  </g>
+                );
+              })()}
+          </g>
+        );
+      })}
+    </ZoomPanSvg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scatter (x = L/R preference, y = score) + declutter
+// ---------------------------------------------------------------------------
+
+function ScatterChart({
+  data,
+  metric,
+  term,
+  domMin,
+  domMax,
+  maxTotal,
+  hover,
+  setHover,
+  metricLabel,
+  labelMode,
+}: ChartProps & { labelMode: "all" | "topN" }) {
+  const X0 = -1.05;
+  const X1 = 1.05;
+  const xBase = (pref: number) => M.left + ((pref - X0) / (X1 - X0)) * PW;
+  const yBase = (score: number) => M.top + PH - ((score - domMin) / (domMax - domMin || 1)) * PH;
+
+  const yTicks = axisTicks(domMin, domMax, 5);
+  const xTicks = [-1, -0.5, 0, 0.5, 1];
+
+  // Which labels render. "all" (scatter) shows every label — overlaps and
+  // all, that's what pan/zoom is for. "topN" (declutter) keeps only the
+  // strongest few and drops any that would clash, for a clean read.
+  const labelled = useMemo(() => {
+    if (labelMode === "all") return new Set(data.map((c) => c.word));
+    const byScore = [...data].sort((a, b) => b[metric] - a[metric]);
+    const pool = byScore.slice(0, 14);
+    const placed: Bounds[] = [];
+    const show = new Set<string>();
+    for (const c of pool) {
+      const cx = xBase(prefRatio(c)) + rFor(c.total, maxTotal) + 5;
+      const cy = yBase(c[metric]);
+      const w = measureWidth(c.word, LABEL_FONT);
+      const box: Bounds = { x: cx, y: cy - 7, w, h: 14 };
+      const clash = placed.some(
+        (p) => box.x < p.x + p.w && box.x + box.w > p.x && box.y < p.y + p.h && box.y + box.h > p.y,
+      );
+      if (!clash) {
+        placed.push(box);
+        show.add(c.word);
+      }
+    }
+    return show;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, metric, domMin, domMax, labelMode, maxTotal]);
+
+  // "all" mode: keep dots at their true position but push the *labels*
+  // apart (collision relaxation, anchored near each dot) so every label is
+  // readable; a leader line links each label back to its dot. Returns a
+  // map word → displaced label centre. null in declutter mode.
+  const placed = useMemo(() => {
+    if (labelMode !== "all") return null;
+    const arr = data.map((c) => {
+      const cx = xBase(prefRatio(c));
+      const cy = yBase(c[metric]);
+      const r = rFor(c.total, maxTotal);
+      const w = measureWidth(c.word, LABEL_FONT);
+      const ax = cx + r + 7 + w / 2; // anchor: just right of the dot
+      return { word: c.word, w, x: ax, y: cy, ax, ay: cy };
+    });
+    for (let it = 0; it < 260; it++) {
+      for (let i = 0; i < arr.length; i++) {
+        for (let j = i + 1; j < arr.length; j++) {
+          const a = arr[i];
+          const b = arr[j];
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          const ox = (a.w + b.w) / 2 + 8 - Math.abs(dx);
+          const oy = 19 - Math.abs(dy);
+          if (ox > 0 && oy > 0) {
+            if (ox < oy) {
+              const m = (ox / 2) * (dx >= 0 ? 1 : -1);
+              a.x -= m;
+              b.x += m;
+            } else {
+              const m = (oy / 2) * (dy >= 0 ? 1 : -1);
+              a.y -= m;
+              b.y += m;
+            }
+          }
+        }
+      }
+      for (const l of arr) {
+        // Weak pull back toward the dot — loose enough that a dense pile-up
+        // can fan out into empty space rather than staying stacked.
+        l.x += (l.ax - l.x) * 0.02;
+        l.y += (l.ay - l.y) * 0.02;
+        l.x = clamp(l.x, M.left + l.w / 2, W - M.right - l.w / 2);
+        l.y = clamp(l.y, M.top + 8, M.top + PH - 8);
+      }
+    }
+    const m = new Map<string, { x: number; y: number; w: number }>();
+    for (const l of arr) m.set(l.word, { x: l.x, y: l.y, w: l.w });
+    return m;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, metric, domMin, domMax, labelMode, maxTotal]);
+
+  // Data extent for the fit control.
+  const bounds = useMemo(() => {
+    if (data.length === 0) return { x: M.left, y: M.top, w: PW, h: PH };
+    let x0 = Infinity;
+    let y0 = Infinity;
+    let x1 = -Infinity;
+    let y1 = -Infinity;
+    for (const c of data) {
+      const px = xBase(prefRatio(c));
+      const py = yBase(c[metric]);
+      x0 = Math.min(x0, px);
+      y0 = Math.min(y0, py);
+      x1 = Math.max(x1, px);
+      y1 = Math.max(y1, py);
+    }
+    const pad = 36;
+    return { x: x0 - pad, y: y0 - pad, w: x1 - x0 + 2 * pad, h: y1 - y0 + 2 * pad };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, metric, domMin, domMax]);
+
+  const nodeX = xBase(0);
+
+  return (
+    <ZoomPanSvg bounds={bounds} autoFit={false} onLeave={() => setHover(null)}>
+      {/* Y gridlines + labels */}
+      {yTicks.map((t) => (
+        <g key={`y-${t}`}>
+          <line x1={M.left} x2={W - M.right} y1={yBase(t)} y2={yBase(t)} stroke="var(--border)" strokeWidth={1} opacity={0.32} />
+          <text x={M.left - 10} y={yBase(t)} textAnchor="end" dominantBaseline="middle" style={{ fontFamily: "var(--font-mono)", fontSize: 10, fill: "var(--fg-subtle)" }}>
+            {fmtTick(t)}
+          </text>
+        </g>
+      ))}
+
+      {/* Y axis title */}
+      <text x={16} y={M.top + PH / 2} textAnchor="middle" dominantBaseline="middle" transform={`rotate(-90 16 ${M.top + PH / 2})`} style={{ fontFamily: "var(--font-mono)", fontSize: 10, fill: "var(--fg-subtle)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+        {metricLabel}
+      </text>
+
+      {/* node (x=0) line */}
+      <line x1={nodeX} x2={nodeX} y1={M.top - 4} y2={H - M.bottom + 4} stroke="var(--accent)" strokeWidth={1} strokeDasharray="3 4" opacity={0.4} />
+      <text x={nodeX} y={M.top - 10} textAnchor="middle" style={{ fontFamily: "var(--font-mono)", fontSize: 11, fill: "var(--accent)", fontWeight: 600 }}>
+        {term}
+      </text>
+
+      {/* X baseline + ticks */}
+      <line x1={M.left} x2={W - M.right} y1={H - M.bottom} y2={H - M.bottom} stroke="var(--border)" />
+      {xTicks.map((t) => (
+        <g key={`x-${t}`}>
+          <line x1={xBase(t)} x2={xBase(t)} y1={H - M.bottom} y2={H - M.bottom + 4} stroke="var(--border)" />
+          <text x={xBase(t)} y={H - M.bottom + 18} textAnchor="middle" style={{ fontFamily: "var(--font-mono)", fontSize: 10, fill: "var(--fg-subtle)" }}>
+            {t === 0 ? "" : t > 0 ? `+${t}` : `${t}`}
+          </text>
+        </g>
+      ))}
+      <text x={M.left} y={H - 8} textAnchor="start" style={{ fontFamily: "var(--font-mono)", fontSize: 10, fill: "var(--fg-subtle)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+        ← left of node
+      </text>
+      <text x={W - M.right} y={H - 8} textAnchor="end" style={{ fontFamily: "var(--font-mono)", fontSize: 10, fill: "var(--fg-subtle)", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+        right of node →
+      </text>
+
+      {/* Data points — hovered drawn last so it reads above its neighbours */}
+      {(hover ? [...data].sort((a, b) => (a.word === hover ? 1 : b.word === hover ? -1 : 0)) : data).map((c) => {
+        const cx = xBase(prefRatio(c));
+        const cy = yBase(c[metric]);
+        const r = rFor(c.total, maxTotal);
+        const color = colorOf(c.pos);
+        const isHover = hover === c.word;
+        const dimmed = hover !== null && !isHover;
+
+        // "all" mode: dot at true position, label displaced + leader line.
+        if (placed) {
+          const p = placed.get(c.word);
+          if (!p) return null;
+          return (
+            <g
+              key={c.word}
+              style={{ cursor: "pointer", opacity: dimmed ? 0.28 : 1 }}
+              onMouseEnter={() => setHover(c.word)}
+              onMouseLeave={() => setHover(null)}
+            >
+              <line x1={cx + r} y1={cy} x2={p.x - p.w / 2 - 3} y2={p.y} stroke={isHover ? color : "var(--border)"} strokeWidth={1} opacity={isHover ? 0.7 : 0.35} />
+              {/* hit area is the label only (tight to the glyphs) — every
+                  label is visible in this mode, so the dot needn't be a
+                  separate, far-from-the-word hit target */}
+              <rect x={p.x - p.w / 2} y={p.y - 8} width={p.w} height={15} fill="transparent" />
+              <circle
+                cx={cx}
+                cy={cy}
+                r={r}
+                fill={color}
+                stroke={color}
+                pointerEvents="none"
+                style={{
+                  fillOpacity: isHover ? 0.5 : 0.22,
+                  strokeWidth: isHover ? 2 : 1.2,
+                  transition: "fill-opacity 130ms var(--ease), stroke-width 130ms var(--ease)",
+                }}
+              />
+              <text
+                x={p.x}
+                y={p.y + 4}
+                textAnchor="middle"
+                style={{
+                  fontFamily: "var(--font-sans)",
+                  fontSize: 12,
+                  fontWeight: 500,
+                  fill: isHover ? "var(--accent)" : "var(--fg)",
+                  pointerEvents: "none",
+                  paintOrder: "stroke",
+                  stroke: "var(--bg)",
+                  strokeWidth: 4,
+                  transition: "fill 130ms var(--ease)",
+                }}
+              >
+                {c.word}
+              </text>
+            </g>
+          );
+        }
+
+        // declutter mode: glued labels, only the top-N shown.
+        const hasLabel = labelled.has(c.word);
+        const showLabel = isHover || hasLabel;
+        const labelW = measureWidth(c.word, LABEL_FONT);
+        const hy = Math.max(r + 2, 11);
+        const hitW = showLabel ? r + 9 + labelW : 2 * r + 8;
+        const hitX = showLabel ? -r - 2 : -r - 4;
+        return (
+          <g
+            key={c.word}
+            transform={`translate(${cx}, ${cy})`}
+            style={{ cursor: "pointer", opacity: dimmed ? 0.28 : 1 }}
+            onMouseEnter={() => setHover(c.word)}
+            onMouseLeave={() => setHover(null)}
+          >
+            <rect x={hitX} y={-hy} width={hitW} height={2 * hy} fill="transparent" />
+            <circle
+              r={r}
+              fill={color}
+              stroke={color}
+              pointerEvents="none"
+              style={{
+                fillOpacity: isHover ? 0.5 : 0.22,
+                strokeWidth: isHover ? 2 : 1.2,
+                transition: "fill-opacity 130ms var(--ease), stroke-width 130ms var(--ease)",
+              }}
+            />
+            {showLabel && (
+              <text
+                x={r + 5}
+                y={4}
+                style={{
+                  fontFamily: "var(--font-sans)",
+                  fontSize: 12,
+                  fontWeight: 500,
+                  fill: isHover ? "var(--accent)" : "var(--fg)",
+                  pointerEvents: "none",
+                  paintOrder: "stroke",
+                  stroke: "var(--bg)",
+                  strokeWidth: 4,
+                  transition: "fill 130ms var(--ease)",
+                }}
+              >
+                {c.word}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </ZoomPanSvg>
   );
 }
 

--- a/app/src/components/analyses/FrequencyView.tsx
+++ b/app/src/components/analyses/FrequencyView.tsx
@@ -20,6 +20,22 @@ export interface FrequencyViewProps {
 const TOP_N = 12;
 const BUCKETS = 100;
 
+/** True only once `active` has stayed true for `delay` ms — so a spinner
+ *  doesn't flash on fast (cached/sidecar) queries. Fast loads resolve
+ *  before the timer fires and never show it; slow ones still do. */
+function useDelayedFlag(active: boolean, delay = 160): boolean {
+  const [on, setOn] = useState(false);
+  useEffect(() => {
+    if (!active) {
+      setOn(false);
+      return;
+    }
+    const id = window.setTimeout(() => setOn(true), delay);
+    return () => window.clearTimeout(id);
+  }, [active, delay]);
+  return on;
+}
+
 interface FreqBarRow {
   primary: string;
   secondary?: string;
@@ -37,8 +53,6 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
   const [by, setBy] = useState<FreqBy>("word");
   const [liveFreq, setLiveFreq] = useState<FreqResultRow[] | null>(null);
   const [liveDist, setLiveDist] = useState<TermDistResult | null>(null);
-  const [freqLoading, setFreqLoading] = useState(false);
-  const [distLoading, setDistLoading] = useState(false);
 
   // Corpus-wide term frequencies on the active layer; refetch when the
   // corpus or the word/POS toggle changes. The backend command is async
@@ -49,14 +63,13 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
     setLiveFreq(null);
     if (!hasLiveData(corpus.id)) return;
     let cancelled = false;
-    setFreqLoading(true);
     runFrequencies({ corpusId: corpus.id, layer: by, limit: TOP_N })
       .then((r) => {
         if (!cancelled) setLiveFreq(r.rows);
       })
-      .catch((e) => console.error("runFrequencies failed:", e))
-      .finally(() => {
-        if (!cancelled) setFreqLoading(false);
+      .catch((e) => {
+        console.error("runFrequencies failed:", e);
+        if (!cancelled) setLiveFreq([]); // clear the spinner on error
       });
     return () => {
       cancelled = true;
@@ -68,14 +81,13 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
     setLiveDist(null);
     if (!hasLiveData(corpus.id) || !term.trim()) return;
     let cancelled = false;
-    setDistLoading(true);
     runTermDistribution({ corpusId: corpus.id, term: term.trim(), layer: by, buckets: BUCKETS })
       .then((r) => {
         if (!cancelled) setLiveDist(r);
       })
-      .catch((e) => console.error("runTermDistribution failed:", e))
-      .finally(() => {
-        if (!cancelled) setDistLoading(false);
+      .catch((e) => {
+        console.error("runTermDistribution failed:", e);
+        if (!cancelled) setLiveDist({ docCounts: [], dispersion: [], totalHits: 0, elapsedMs: 0 });
       });
     return () => {
       cancelled = true;
@@ -83,6 +95,15 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
   }, [corpus.id, term, by]);
 
   const isLive = hasLiveData(corpus.id);
+  // For a live corpus, show the spinner until the *real* data arrives —
+  // never flash the fixture rows (which would look like the bars
+  // reshuffling from demo terms into the real ones).
+  const freqPending = isLive && !liveFreq;
+  const distPending = isLive && !liveDist;
+  // Only surface the spinner if the query is actually slow; a fast load
+  // resolves first and the bars just grow in — no spinner flash.
+  const showFreqSpinner = useDelayedFlag(freqPending);
+  const showDistSpinner = useDelayedFlag(distPending);
   const fixtureDispersion = useMemo(() => makeDispersion(42), []);
 
   // --- Normalise live or fixture data into uniform render rows. ---
@@ -144,15 +165,19 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
             <div className="cx-card-meta">n = {corpus.tokenCount.toLocaleString()} tokens</div>
           </div>
           <div className="cx-card-body">
-            {isLive && freqLoading ? (
-              <div className="cx-loading-row">
-                <span className="cx-spinner" /> computing frequencies…
-              </div>
+            {freqPending ? (
+              showFreqSpinner ? (
+                <div className="cx-loading-row">
+                  <span className="cx-spinner" /> computing frequencies…
+                </div>
+              ) : null
             ) : (
-            freqRows.map((row) => {
+            freqRows.map((row, i) => {
               const w = (row.count / maxCount) * 100;
               return (
-                <div key={row.primary} className="cx-freq-bar-row">
+                // keyed by rank, not term: the slot stays put while its
+                // contents swap, so bars don't reorder mid grow-animation.
+                <div key={i} className="cx-freq-bar-row">
                   <span className={`word ${by === "pos" ? "is-pos" : ""}`}>
                     {row.secondary ? `${row.primary} · ${row.secondary}` : row.primary}
                   </span>
@@ -176,10 +201,12 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
             </div>
           </div>
           <div className="cx-card-body">
-            {isLive && distLoading ? (
-              <div className="cx-loading-row">
-                <span className="cx-spinner" /> computing dispersion…
-              </div>
+            {distPending ? (
+              showDistSpinner ? (
+                <div className="cx-loading-row">
+                  <span className="cx-spinner" /> computing dispersion…
+                </div>
+              ) : null
             ) : (
             <>
             <div className="cx-disp">
@@ -199,9 +226,9 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
               <span>top documents</span>
               <span className="sub">hits · per 1M tokens</span>
             </div>
-            {docFreq.slice(0, 8).map((d) => (
+            {docFreq.slice(0, 8).map((d, i) => (
               <div
-                key={d.doc}
+                key={i}
                 className="cx-freq-bar-row"
                 style={{ gridTemplateColumns: "140px 1fr 50px 60px" }}
               >

--- a/app/src/components/analyses/WordTree.tsx
+++ b/app/src/components/analyses/WordTree.tsx
@@ -1,0 +1,286 @@
+// Word tree — a branching view of what follows (or precedes) the node,
+// à la Wattenberg & Viégas. Built client-side from the concordance hits:
+// each hit's right (or left) context is a token sequence; we trie them up
+// and lay the trie out left→right, sizing each word by how many lines run
+// through it. Great for seeing phraseology at a glance — e.g. for a
+// sanctions corpus, `gold →` reserves / bars / "of Russian origin".
+
+import { useMemo, useState } from "react";
+import type { KwicResult } from "@/types";
+
+export interface WordTreeProps {
+  corpusName: string;
+  term: string;
+  /** Concordance result; its hits supply the context sequences. */
+  result: KwicResult | null;
+  loading?: boolean;
+}
+
+const DEPTH = 4; // context tokens per branch
+const MAX_CHILDREN = 6; // keep each node's busiest continuations
+const COL_W = 148;
+const ROW_H = 22;
+const PAD_X = 16;
+
+const CHAR_W = 7.4; // sans @ ~13px, rough — only for edge endpoints
+
+interface Trie {
+  word: string;
+  count: number;
+  children: Map<string, Trie>;
+}
+
+function tokenize(s: string): string[] {
+  return s
+    .split(/\s+/)
+    .map((t) => t.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, "").toLowerCase())
+    .filter(Boolean);
+}
+
+interface Placed {
+  id: number;
+  word: string;
+  count: number;
+  depth: number;
+  x: number;
+  y: number;
+  parent: number | null;
+}
+
+export function WordTree({ corpusName, term, result, loading = false }: WordTreeProps) {
+  const [dir, setDir] = useState<"right" | "left">("right");
+
+  const hits = result?.hits ?? [];
+
+  const { placed, height, leaves } = useMemo(() => {
+    // Build the trie from each hit's context, trimmed to DEPTH tokens.
+    const root: Trie = { word: term, count: 0, children: new Map() };
+    for (const h of hits) {
+      let seq = tokenize(dir === "right" ? h.right : h.left);
+      if (dir === "left") seq = seq.reverse(); // nearest-to-node first
+      seq = seq.slice(0, DEPTH);
+      root.count += 1;
+      let node = root;
+      for (const w of seq) {
+        let child = node.children.get(w);
+        if (!child) {
+          child = { word: w, count: 0, children: new Map() };
+          node.children.set(w, child);
+        }
+        child.count += 1;
+        node = child;
+      }
+    }
+
+    // Count leaves (for canvas height) after pruning to MAX_CHILDREN.
+    const prune = (n: Trie): Trie => ({
+      ...n,
+      children: new Map(
+        [...n.children.values()]
+          .sort((a, b) => b.count - a.count)
+          .slice(0, MAX_CHILDREN)
+          .map((c) => [c.word, prune(c)]),
+      ),
+    });
+    const pruned = prune(root);
+
+    const countLeaves = (n: Trie): number => {
+      if (n.children.size === 0) return 1;
+      return [...n.children.values()].reduce((s, c) => s + countLeaves(c), 0);
+    };
+    const leaves = countLeaves(pruned);
+    const height = Math.max(360, leaves * ROW_H + 40);
+
+    // Band layout: each node owns a vertical band sized by its frequency;
+    // it sits at the band's centre, children split the band beneath it.
+    const placed: Placed[] = [];
+    let nextId = 0;
+    const walk = (n: Trie, depth: number, yTop: number, yBottom: number, parent: number | null) => {
+      const id = nextId++;
+      const y = (yTop + yBottom) / 2;
+      const x = dir === "right" ? PAD_X + depth * COL_W : 0; // x for left dir fixed up after width known
+      placed.push({ id, word: n.word, count: n.count, depth, x, y, parent });
+      const kids = [...n.children.values()];
+      const total = kids.reduce((s, k) => s + k.count, 0) || 1;
+      let cursor = yTop;
+      for (const k of kids) {
+        const band = (k.count / total) * (yBottom - yTop);
+        walk(k, depth + 1, cursor, cursor + band, id);
+        cursor += band;
+      }
+    };
+    walk(pruned, 0, 20, height - 20, null);
+
+    return { placed, height, leaves };
+  }, [hits, term, dir]);
+
+  const maxDepth = placed.reduce((m, p) => Math.max(m, p.depth), 0);
+  const width = PAD_X * 2 + (maxDepth + 1) * COL_W;
+
+  // For the left direction we mirror x so the node sits on the right and
+  // branches grow leftward.
+  const xOf = (p: Placed) => (dir === "right" ? p.x : width - PAD_X - p.depth * COL_W);
+  const byId = new Map(placed.map((p) => [p.id, p]));
+
+  const maxCount = placed.reduce((m, p) => Math.max(m, p.count), 1);
+  const fontFor = (count: number) => Math.min(28, 12 + Math.log2(count + 1) * 1.8);
+
+  // Hovering a word lights up the branch it belongs to: its ancestors
+  // (the phrase leading to it) and its descendants (the continuations).
+  const [hoverId, setHoverId] = useState<number | null>(null);
+  const childrenOf = useMemo(() => {
+    const m = new Map<number, number[]>();
+    for (const p of placed) {
+      if (p.parent != null) {
+        const arr = m.get(p.parent) ?? [];
+        arr.push(p.id);
+        m.set(p.parent, arr);
+      }
+    }
+    return m;
+  }, [placed]);
+  const connected = useMemo(() => {
+    if (hoverId == null) return null;
+    const set = new Set<number>();
+    // ancestors (incl. self)
+    let cur: number | null = hoverId;
+    while (cur != null) {
+      set.add(cur);
+      cur = byId.get(cur)?.parent ?? null;
+    }
+    // descendants
+    const stack = [hoverId];
+    while (stack.length) {
+      const id = stack.pop() as number;
+      for (const c of childrenOf.get(id) ?? []) {
+        set.add(c);
+        stack.push(c);
+      }
+    }
+    return set;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hoverId, placed]);
+  const on = (id: number) => connected == null || connected.has(id);
+
+  const empty = !loading && hits.length === 0;
+
+  return (
+    <div className="cx-coll-wrap">
+      <div className="cx-coll-main">
+        <div className="cx-coll-head">
+          <h2 className="cx-coll-title">
+            word tree · <span className="kw">{term}</span>{" "}
+            <span style={{ color: "var(--fg-muted)", fontSize: 14 }}>· {corpusName}</span>
+          </h2>
+          <div className="cx-coll-controls">
+            <span>direction</span>
+            <div className="cx-coll-segbtn">
+              {(
+                [
+                  ["right", "following →"],
+                  ["left", "← preceding"],
+                ] as const
+              ).map(([k, l]) => (
+                <button key={k} type="button" className={dir === k ? "is-on" : ""} onClick={() => setDir(k)}>
+                  {l}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="cx-coll-graph" style={{ overflow: "auto", height: "clamp(460px, 60vh, 780px)" }}>
+          {loading ? (
+            <div className="cx-loading-row" style={{ justifyContent: "center", height: "100%" }}>
+              <span className="cx-spinner" /> building tree…
+            </div>
+          ) : empty ? (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                height: "100%",
+                fontFamily: "var(--font-mono)",
+                fontSize: 12,
+                color: "var(--fg-subtle)",
+              }}
+            >
+              no concordance lines for “{term}” to branch from
+            </div>
+          ) : (
+            <svg width={width} height={height} style={{ display: "block", fontFamily: "var(--font-sans)" }}>
+              {/* edges — an edge lights up when both ends are on the
+                  hovered branch */}
+              {placed.map((p) => {
+                if (p.parent == null) return null;
+                const parent = byId.get(p.parent);
+                if (!parent) return null;
+                const px = dir === "right" ? xOf(parent) + parent.word.length * CHAR_W + 6 : xOf(parent) - parent.word.length * CHAR_W - 6;
+                const cx = dir === "right" ? xOf(p) - 6 : xOf(p) + 6;
+                const mx = (px + cx) / 2;
+                const lit = on(p.id) && on(p.parent);
+                return (
+                  <path
+                    key={`e-${p.id}`}
+                    d={`M ${px} ${parent.y} C ${mx} ${parent.y}, ${mx} ${p.y}, ${cx} ${p.y}`}
+                    fill="none"
+                    stroke={lit && connected != null ? "var(--accent)" : "var(--border)"}
+                    strokeWidth={Math.max(0.6, Math.min(4, (p.count / maxCount) * 4))}
+                    opacity={connected == null ? 0.5 : lit ? 0.9 : 0.08}
+                    style={{ transition: "opacity 120ms var(--ease), stroke 120ms var(--ease)" }}
+                  />
+                );
+              })}
+              {/* nodes */}
+              {placed.map((p) => {
+                const isRoot = p.parent == null;
+                const fs = isRoot ? 18 : fontFor(p.count);
+                const lit = on(p.id);
+                return (
+                  <g
+                    key={p.id}
+                    transform={`translate(${xOf(p)}, ${p.y})`}
+                    onMouseEnter={() => setHoverId(p.id)}
+                    onMouseLeave={() => setHoverId(null)}
+                    style={{ cursor: "pointer", opacity: lit ? 1 : 0.22, transition: "opacity 120ms var(--ease)" }}
+                  >
+                    <text
+                      textAnchor={dir === "right" ? "start" : "end"}
+                      dominantBaseline="middle"
+                      style={{
+                        fontSize: fs,
+                        fontWeight: isRoot ? 700 : 400,
+                        fill: isRoot || (connected != null && p.id === hoverId) ? "var(--accent)" : "var(--fg)",
+                      }}
+                    >
+                      {p.word}
+                    </text>
+                    {!isRoot && (
+                      <text
+                        x={dir === "right" ? p.word.length * (fs * 0.55) + 6 : -(p.word.length * (fs * 0.55) + 6)}
+                        textAnchor={dir === "right" ? "start" : "end"}
+                        dominantBaseline="middle"
+                        style={{ fontSize: 10, fill: "var(--fg-subtle)", fontFamily: "var(--font-mono)" }}
+                      >
+                        {p.count}
+                      </text>
+                    )}
+                  </g>
+                );
+              })}
+            </svg>
+          )}
+        </div>
+
+        <div className="cx-coll-legend">
+          <span className="cx-coll-leg-note">
+            branches from {hits.length.toLocaleString()} concordance line{hits.length === 1 ? "" : "s"} · {leaves}{" "}
+            distinct path{leaves === 1 ? "" : "s"} · text size ∝ frequency
+            {result?.truncated ? " · (first 200 lines)" : ""}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/chrome/StatusBar.tsx
+++ b/app/src/components/chrome/StatusBar.tsx
@@ -50,7 +50,12 @@ export function StatusBar({ corpus, result, layer, memory = 0.42 }: StatusBarPro
             {result.truncated && (
               <>
                 <span className="cx-sep">·</span>
-                <span className="cx-warn">truncated</span>
+                <span
+                  className="cx-status-dim"
+                  title={`More matches exist than the ${result.hits.length.toLocaleString()}-line display cap; showing the first ${result.hits.length.toLocaleString()}. Frequency and collocation stats still use the whole corpus.`}
+                >
+                  first {result.hits.length.toLocaleString()} shown
+                </span>
               </>
             )}
           </>

--- a/app/src/components/chrome/ViewTabs.tsx
+++ b/app/src/components/chrome/ViewTabs.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Network, Table2 } from "lucide-react";
+import { BarChart3, Grid3x3, ListTree, Network, Table2 } from "lucide-react";
 import type { KwicResult, SubView } from "@/types";
 
 export interface ViewTabsProps {
@@ -15,8 +15,10 @@ export function ViewTabs({ view, onView, result }: ViewTabsProps) {
     count: number | null;
   }[] = [
     { id: "kwic", label: "concordance", Icon: Table2, count: result ? result.hits.length : null },
-    { id: "coll", label: "collocations", Icon: Network, count: 14 },
+    { id: "coll", label: "collocations", Icon: Network, count: null },
     { id: "freq", label: "frequency", Icon: BarChart3, count: null },
+    { id: "tree", label: "word tree", Icon: ListTree, count: null },
+    { id: "dist", label: "distance", Icon: Grid3x3, count: null },
   ];
   return (
     <div className="cx-viewtabs">

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -90,6 +90,17 @@
     -moz-osx-font-smoothing: grayscale;
     font-feature-settings: "rlig" 1, "calt" 1, "ss01" 1;
     overflow: hidden;
+    /* UI chrome isn't selectable — it's an app, not a document. Specific
+       content surfaces opt back in below. */
+    user-select: none;
+    -webkit-user-select: none;
+  }
+  /* Selectable content: form fields, the concordance lines, and the
+     context-drawer reading pane — the actual corpus text a user copies.
+     Stats tables and chrome stay non-selectable. */
+  input, textarea, .cx-kwic, .cx-drawer-body {
+    user-select: text;
+    -webkit-user-select: text;
   }
   ::selection { background: color-mix(in oklch, var(--accent) 35%, transparent); color: var(--fg); }
   @media (prefers-reduced-motion: reduce) {
@@ -647,12 +658,23 @@
 .cx-coll-segbtn button:disabled { opacity: 0.4; cursor: not-allowed; }
 
 .cx-coll-graph {
-  position: relative; height: 380px;
+  position: relative; height: clamp(460px, 60vh, 780px);
   background: var(--bg-raised); border: 1px solid var(--border);
   border-radius: var(--radius-md);
   margin-bottom: 8px; overflow: hidden;
 }
 .cx-coll-svg-wrap { padding: 0; }
+
+/* collocation-by-distance heatmap */
+.cx-dist-msg { display: flex; align-items: center; justify-content: center; height: 100%; font-family: var(--font-mono); font-size: 12px; color: var(--fg-subtle); text-align: center; }
+.cx-dist-table { border-collapse: collapse; font-family: var(--font-mono); font-size: 11px; }
+.cx-dist-table th { color: var(--fg-subtle); font-weight: 400; padding: 4px 0; text-align: center; }
+.cx-dist-word { text-align: left !important; color: var(--fg); padding-right: 12px !important; white-space: nowrap; position: sticky; left: 0; background: var(--bg-raised); }
+.cx-dist-total { color: var(--fg-subtle); font-size: 10px; }
+.cx-dist-col { width: 40px; }
+.cx-dist-node { color: var(--accent); font-style: italic; padding: 0 8px; }
+.cx-dist-cell { width: 40px; height: 22px; text-align: center; color: var(--fg); border: 1px solid var(--border); }
+.cx-dist-nodecell { width: 14px; border-left: 1px dashed var(--accent); border-right: 1px dashed var(--accent); opacity: 0.5; }
 
 .cx-coll-legend {
   display: flex; gap: 14px;
@@ -735,7 +757,9 @@
 .cx-freq-bar-row .word.is-pos { color: var(--layer-pos); }
 .cx-freq-bar-row .count { text-align: right; color: var(--fg-muted); }
 .cx-freq-bar-row .pct { text-align: right; color: var(--fg-subtle); font-size: 10px; }
-.cx-freq-bar { height: 6px; border-radius: 2px; background: color-mix(in oklch, var(--accent) 70%, transparent); transition: width var(--dur-2) var(--ease); }
+.cx-freq-bar { height: 6px; border-radius: 2px; background: color-mix(in oklch, var(--accent) 70%, transparent); transform-origin: left center; animation: cx-bar-grow var(--dur-2) var(--ease) both; }
+@keyframes cx-bar-grow { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+@media (prefers-reduced-motion: reduce) { .cx-freq-bar { animation: none; } }
 
 .cx-disp { position: relative; height: 96px; background: var(--bg-inset); border-radius: var(--radius-sm); border: 1px solid var(--border); overflow: hidden; }
 .cx-disp-mark { position: absolute; top: 0; bottom: 0; width: 1px; background: var(--accent); opacity: 0.6; }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -103,6 +103,31 @@ export interface TermDistResult {
   elapsedMs: number;
 }
 
+export interface CollocateDistanceRequest {
+  corpusId: string;
+  term: string;
+  layer: QueryLayer;
+  leftWindow: number;
+  rightWindow: number;
+  limit: number;
+}
+
+export interface DistanceRow {
+  word: string;
+  total: number;
+  /** One count per offset in `offsets` (same order). */
+  counts: number[];
+}
+
+export interface CollocateDistanceResult {
+  /** Signed slot offsets, e.g. [-3,-2,-1,1,2,3]. */
+  offsets: number[];
+  rows: DistanceRow[];
+  nodeHits: number;
+  truncated: boolean;
+  elapsedMs: number;
+}
+
 export interface ExpandRequest {
   corpusId: string;
   docId: number;
@@ -147,6 +172,12 @@ export async function listDocuments(corpusId: string): Promise<DocumentInfo[]> {
 
 export async function runFrequencies(req: FrequenciesRequest): Promise<FrequenciesResult> {
   return invokeSafe<FrequenciesResult>("run_frequencies", { req });
+}
+
+export async function runCollocateDistance(
+  req: CollocateDistanceRequest,
+): Promise<CollocateDistanceResult> {
+  return invokeSafe<CollocateDistanceResult>("run_collocate_distance", { req });
 }
 
 export async function runTermDistribution(req: TermDistRequest): Promise<TermDistResult> {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -125,7 +125,7 @@ export interface BuildProgress {
 }
 
 export type MainView = "search" | "corpus" | "settings";
-export type SubView = "kwic" | "coll" | "freq";
+export type SubView = "kwic" | "coll" | "freq" | "tree" | "dist";
 export type SortMode = "left1" | "right1" | "doc";
 export type SortDir = "asc" | "desc";
 export type CollMetric = "logDice" | "mi" | "z";

--- a/crates/corpust-index/src/lib.rs
+++ b/crates/corpust-index/src/lib.rs
@@ -175,6 +175,19 @@ pub struct CollocateScan {
     pub truncated: bool,
 }
 
+/// Per-collocate counts bucketed by signed distance from the node, for
+/// the collocation-by-distance view. `slots` runs `[-left … -1, +1 … +right]`
+/// (the node position itself is excluded).
+#[derive(Debug, Clone)]
+pub struct DistanceProfile {
+    pub node_freq: u64,
+    /// The signed offsets the columns correspond to, e.g. `[-3,-2,-1,1,2,3]`.
+    pub offsets: Vec<i32>,
+    /// Per collocate word: a count for each offset in `offsets` (same length).
+    pub rows: HashMap<String, Vec<u32>>,
+    pub truncated: bool,
+}
+
 /// Corpus-wide distribution of a term: per-document hit counts plus a
 /// dispersion histogram over the whole corpus.
 #[derive(Debug, Clone)]
@@ -848,6 +861,114 @@ impl CorpusIndex {
         Ok(scan)
     }
 
+    /// Like [`Self::collocate_counts`] but keeps each collocate's count
+    /// bucketed by **signed distance** from the node (`-left … -1, +1 …
+    /// +right`), powering the collocation-by-distance view. One positional
+    /// pass; tokens are sliced by their stored offsets so a distance maps
+    /// to exactly one token.
+    pub fn collocate_by_distance(
+        &self,
+        term: &str,
+        layer: QueryLayer,
+        left: usize,
+        right: usize,
+        max_nodes: usize,
+    ) -> Result<DistanceProfile> {
+        let (query_field, lookup_term) = match layer {
+            QueryLayer::Word => (self.fields.body, term.to_lowercase()),
+            QueryLayer::Lemma => (self.fields.body_lemma, term.to_lowercase()),
+            QueryLayer::Pos => (self.fields.body_pos, term.to_string()),
+        };
+        let offsets_axis: Vec<i32> = (1..=left as i32)
+            .rev()
+            .map(|d| -d)
+            .chain(1..=right as i32)
+            .collect();
+        let slot_of = |d: i32| -> usize {
+            if d < 0 {
+                (d + left as i32) as usize
+            } else {
+                left + (d as usize - 1)
+            }
+        };
+
+        let searcher = self.reader.searcher();
+        let term_obj = Term::from_field_text(query_field, &lookup_term);
+        let mut rows: HashMap<String, Vec<u32>> = HashMap::new();
+        let slots = left + right;
+        let mut node_freq: u64 = 0;
+        let mut truncated = false;
+        let mut positions_buf: Vec<u32> = Vec::new();
+
+        'segments: for (seg_ord, seg_reader) in searcher.segment_readers().iter().enumerate() {
+            let inv_idx = seg_reader.inverted_index(query_field)?;
+            let Some(mut postings) =
+                inv_idx.read_postings(&term_obj, IndexRecordOption::WithFreqsAndPositions)?
+            else {
+                continue;
+            };
+            loop {
+                let doc = postings.doc();
+                if doc == TERMINATED {
+                    continue 'segments;
+                }
+                let doc_addr = DocAddress::new(seg_ord as u32, doc);
+                let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
+                let body = retrieved
+                    .get_first(self.fields.body)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+                let offsets = bytes_to_offsets(
+                    retrieved
+                        .get_first(self.fields.token_offsets)
+                        .and_then(|v| v.as_bytes())
+                        .unwrap_or_default(),
+                );
+                let n = offsets.len();
+                let start_of = |i: usize| -> usize {
+                    if i < n {
+                        offsets[i] as usize
+                    } else {
+                        body.len()
+                    }
+                };
+
+                positions_buf.clear();
+                postings.positions(&mut positions_buf);
+                for &pos in &positions_buf {
+                    if node_freq as usize >= max_nodes {
+                        truncated = true;
+                        break 'segments;
+                    }
+                    node_freq += 1;
+                    let p = pos as usize;
+                    if p >= n {
+                        continue;
+                    }
+                    let lo = p.saturating_sub(left);
+                    let hi = (p + right + 1).min(n);
+                    for i in lo..hi {
+                        if i == p {
+                            continue;
+                        }
+                        if let Some(w) = normalize_token(&body[start_of(i)..start_of(i + 1)]) {
+                            let slot = slot_of(i as i32 - p as i32);
+                            rows.entry(w).or_insert_with(|| vec![0u32; slots])[slot] += 1;
+                        }
+                    }
+                }
+                postings.advance();
+            }
+        }
+
+        Ok(DistanceProfile {
+            node_freq,
+            offsets: offsets_axis,
+            rows,
+            truncated,
+        })
+    }
+
     /// Per-document hit counts and a corpus-wide dispersion histogram for
     /// a single term on `layer`, in one pass over the term's postings.
     ///
@@ -1042,29 +1163,32 @@ fn window(
     p: usize,
     context: usize,
 ) -> Option<(String, String, String)> {
-    if p >= offsets.len() {
+    let n = offsets.len();
+    if p >= n {
         return None;
     }
     let window_start = p.saturating_sub(context);
-    let window_end = (p + context + 1).min(offsets.len());
-    let byte_start = offsets[window_start] as usize;
-    let byte_end = if window_end < offsets.len() {
-        offsets[window_end] as usize
-    } else {
-        body.len()
-    };
+    let window_end = (p + context + 1).min(n); // exclusive token index
 
-    let window_text = &body[byte_start..byte_end];
-    let window_tokens: Vec<&str> = window_text.unicode_words().collect();
-    let hit_idx = p - window_start;
-    if hit_idx >= window_tokens.len() {
-        return None;
-    }
-    Some((
-        window_tokens[..hit_idx].join(" "),
-        window_tokens[hit_idx].to_string(),
-        window_tokens[hit_idx + 1..].join(" "),
-    ))
+    // Slice each token directly by its stored byte offset. `offsets[i]` is
+    // the start of token `i`; the start of token `i+1` (or end of body) is
+    // its end. This keeps the displayed hit aligned with the indexed
+    // position `p` even when the indexing tokenizer (an annotator's
+    // tokenisation) splits the text differently from a naive
+    // re-tokenisation — re-tokenising here silently mis-aligned the hit on
+    // annotated corpora.
+    let start_of = |i: usize| -> usize {
+        if i < n {
+            offsets[i] as usize
+        } else {
+            body.len()
+        }
+    };
+    let left = body[start_of(window_start)..start_of(p)].trim();
+    let hit = body[start_of(p)..start_of(p + 1)].trim();
+    let right = body[start_of(p + 1)..start_of(window_end)].trim();
+
+    Some((left.to_owned(), hit.to_owned(), right.to_owned()))
 }
 
 /// Which side of the node a window extends to.
@@ -1099,6 +1223,22 @@ fn window_side(body: &str, offsets: &[u32], p: usize, count: usize, side: Side) 
         body.len()
     };
     tokenize_for_collocates(&body[byte_start..byte_end]).collect()
+}
+
+/// Normalise a single token slice for collocate counting: lowercase,
+/// strip edge punctuation, drop empty/single-character and pure-digit
+/// tokens. Returns `None` for tokens that aren't collocate candidates.
+fn normalize_token(raw: &str) -> Option<String> {
+    let trimmed: String = raw
+        .trim_matches(|c: char| !c.is_alphanumeric())
+        .to_lowercase();
+    if trimmed.chars().count() < 2 {
+        return None;
+    }
+    if trimmed.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(trimmed)
 }
 
 /// Split a window substring into collocate candidates:
@@ -1588,6 +1728,25 @@ mod tests {
         // 2(cat) + 1(on) + 1(and) + 1(mat) + 1(dog) collocate slots filled.
         assert_eq!(scan.window_tokens, 6);
 
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn collocate_by_distance_buckets_offsets() {
+        // doc0: the(0) cat(1) sat(2) on(3) the(4) mat(5)
+        // doc1: the(0) dog(1) and(2) the(3) cat(4)
+        let (tmp, idx) = two_doc_index();
+        let prof = idx
+            .collocate_by_distance("the", QueryLayer::Word, 1, 1, usize::MAX)
+            .unwrap();
+        assert_eq!(prof.node_freq, 4);
+        assert_eq!(prof.offsets, vec![-1, 1]);
+        // cat: never immediately left of "the", twice immediately right.
+        assert_eq!(prof.rows.get("cat"), Some(&vec![0, 2]));
+        // on / and precede a "the"; mat / dog follow one.
+        assert_eq!(prof.rows.get("on"), Some(&vec![1, 0]));
+        assert_eq!(prof.rows.get("and"), Some(&vec![1, 0]));
+        assert_eq!(prof.rows.get("mat"), Some(&vec![0, 1]));
         let _ = std::fs::remove_dir_all(&tmp);
     }
 


### PR DESCRIPTION
A big pass over the analysis surfaces, plus two correctness fixes uncovered along the way.

## Collocations
- **network** (GraphColl-style radial) + **scatter** views, with a **declutter** toggle (merging the old separate mode).
- Shared **pan/zoom canvas**: scroll-to-zoom, drag-to-pan, fit-to-content button, zoom slider; wheel no longer scrolls the page; no text selection on drag.
- Even radial layout (no one-sided column stacking), label collision spread + leader lines in scatter, data-fit & signed y-axis.
- Smooth hover (color ease — no font-weight jump/corner-scale), full dot+label hit target, raise-to-front, no stuck hover, legible readout panel.
- Loading polish: delayed spinner (no flash on fast/sidecar queries), no fixture flash, "no collocates" empty state (POS layer hints to search a tag). Chart order **decoupled from table sort** (sorting the table no longer reshuffles the graph).

## New analysis tabs
- **Word tree** — branching phrases from the concordance (following → / ← preceding); hovering a word **lights up its whole branch** (ancestors + continuations), dimming the rest.
- **Collocation-by-distance** — heatmap of each collocate's count at slots **L5…R5** (new `collocate_by_distance` index scan + `run_collocate_distance` command, unit-tested).

## Responsiveness (frequency)
Delayed spinner, **grow-from-zero** bars without reorder, softened "first N shown" status.

## Bug fixes
- **KWIC hit misalignment** on annotated corpora: `window()` now slices tokens by their stored `token_offsets` instead of re-tokenising — fixes the wrong hit token (`philologist` shown for a `linguistic` search) and the word-tree phantom node.
- **Stale fixture corpus** in the concordance: consolidated the KWIC fetch to one request-id-guarded path so the active corpus always wins (a real corpus could previously keep showing a fixture corpus's hits).

## App-wide
UI chrome is non-selectable; selection opted in only for the concordance, context drawer, and form fields.

## Verification
`cargo build` / `clippy --workspace` / `fmt --check` clean; index tests (incl. new distance + window) + 55 frontend tests green.

## Follow-ups filed
#31 (POS colours) · #32 (concordance paging) · #33 (horizontal overflow) · #34 (freq-over-time) · #35 (term×period heatmap) · #36 (n-grams) · #37 (keyness) · #38 (collocation diff). Also #27 (MCP) · #28 (graph export) · #29 (drill-in) · #30 (filter).

Note: POS-colour and the remaining viz are intentionally deferred to issues; this PR is the viz framework + word tree + distance + the two fixes.