### PR TITLE
Clear collocations on empty term + exclude node from its own collocates

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -191,9 +191,13 @@ fn run_collocates_inner(
             // candidate pool rather than every distinct collocate type
             // (which can be tens of thousands for a frequent node).
             let pool = (limit * 8).max(200);
+            // Exclude the node from its own collocate list (it co-occurs
+            // with itself within the window, e.g. "the Jew … the Jew").
+            let node_word = req.term.trim().to_lowercase();
             let mut cand: Vec<(String, u32, u32)> = scan
                 .counts
                 .iter()
+                .filter(|(w, _)| **w != node_word)
                 .map(|(w, &(l, r))| (w.clone(), l, r))
                 .collect();
             cand.sort_by(|a, b| (b.1 + b.2).cmp(&(a.1 + a.2)).then_with(|| a.0.cmp(&b.0)));
@@ -469,9 +473,11 @@ fn run_collocate_distance_inner(
         let prof = index
             .collocate_by_distance(&req.term, layer, lw, rw, MAX_NODE_OCCURRENCES)
             .map_err(|e| format!("distance scan failed: {e:#}"))?;
+        let node_word = req.term.trim().to_lowercase();
         let rows: Vec<DistanceRow> = prof
             .rows
             .into_iter()
+            .filter(|(word, _)| *word != node_word) // exclude the node itself
             .map(|(word, counts)| {
                 let total = counts.iter().sum();
                 DistanceRow {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -181,7 +181,16 @@ export function App() {
   // out-of-order responses so a stale answer can't clobber a fresh one.
   const collReqRef = useRef(0);
   const fetchCollocates = () => {
-    if (subview !== "coll" || !activeCorpus || !term.trim()) return;
+    if (subview !== "coll" || !activeCorpus) return;
+    // Empty query: clear stale collocates instead of leaving the last
+    // result on screen with a blank node.
+    if (!term.trim()) {
+      collReqRef.current++;
+      setCollocates(inTauri() && !CORPORA.some((c) => c.id === activeCorpus.id) ? [] : null);
+      setCollLoading(false);
+      setCollTruncated(false);
+      return;
+    }
     if (!inTauri() || CORPORA.some((c) => c.id === activeCorpus.id)) {
       setCollocates(null);
       setCollLoading(false);

--- a/app/src/components/analyses/CollocationsView.tsx
+++ b/app/src/components/analyses/CollocationsView.tsx
@@ -348,9 +348,11 @@ export function CollocationsView({
                 padding: 24,
               }}
             >
-              {layer === "pos"
-                ? `no matches for “${term}” on the POS layer — search a tag (NN, VB, JJ…)`
-                : `no collocates for “${term}” on this layer`}
+              {!term.trim()
+                ? "enter a search term to see its collocates"
+                : layer === "pos"
+                  ? `no matches for “${term}” on the POS layer — search a tag (NN, VB, JJ…)`
+                  : `no collocates for “${term}” on this layer`}
             </div>
           ) : vizMode === "network" ? (
             <NetworkChart {...chartProps} />


### PR DESCRIPTION
Two collocation bug fixes spotted in the app.

1. **Empty term leaves a stale graph.** Clearing the search box kept the last collocation network on screen with a blank centre node. `fetchCollocates` now clears collocates when the term is empty, and `CollocationsView` shows an "enter a search term to see its collocates" prompt instead.
2. **Node was its own collocate.** A node co-occurs with itself within the window (e.g. "the Jew … the Jew"), so it appeared in its own collocate list/graph. Excluded the node word from both `run_collocates` and `run_collocate_distance` results (standard for collocation tools).

## Verification
`cargo clippy --workspace` + `fmt` clean; index tests (25) + frontend build + 55 frontend tests green.