### PR TITLE
Paginate the concordance (offset + total)

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -277,16 +277,20 @@ fn run_kwic_inner(state: &State<'_, AppState>, req: &KwicRequest) -> Result<Kwic
     let kreq = CoreKwicRequest::new(&req.term)
         .layer(req.layer.into())
         .context(context)
-        .limit(limit);
+        .limit(limit)
+        .offset(req.offset);
 
     let t0 = Instant::now();
-    let hits = with_corpus(state, &req.corpus_id, |index| {
+    let page = with_corpus(state, &req.corpus_id, |index| {
         run_core_kwic(index, kreq).map_err(|e| format!("kwic failed: {e:#}"))
     })?;
     let elapsed_ms = t0.elapsed().as_secs_f64() * 1000.0;
-    let truncated = hits.len() == limit;
+    let total = page.total;
+    // "truncated" now just means there are more pages after this one.
+    let truncated = req.offset + page.hits.len() < total;
     Ok(KwicResult {
-        hits: hits
+        hits: page
+            .hits
             .into_iter()
             .map(|h| KwicHitDto {
                 doc_id: h.doc_id,
@@ -299,6 +303,8 @@ fn run_kwic_inner(state: &State<'_, AppState>, req: &KwicRequest) -> Result<Kwic
             .collect(),
         elapsed_ms,
         truncated,
+        total: total as u64,
+        offset: req.offset as u64,
     })
 }
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -95,6 +95,9 @@ pub struct KwicRequest {
     pub layer: QueryLayer,
     pub context: usize,
     pub limit: usize,
+    /// Hits to skip before this page (concordance pagination).
+    #[serde(default)]
+    pub offset: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -116,6 +119,10 @@ pub struct KwicResult {
     pub hits: Vec<KwicHit>,
     pub elapsed_ms: f64,
     pub truncated: bool,
+    /// Total matches across the whole corpus (paging denominator).
+    pub total: u64,
+    /// Index of the first hit in this page (0-based), for "N–M of total".
+    pub offset: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -37,6 +37,9 @@ import type {
   SubView,
 } from "@/types";
 
+/** Concordance lines fetched per page. */
+const KWIC_PAGE = 200;
+
 export function App() {
   const [corpora, setCorpora] = useState<CorpusMeta[]>(CORPORA);
   const [activeId, setActiveId] = useState<string | null>("gut-en");
@@ -117,58 +120,65 @@ export function App() {
   // A request-id guard drops superseded responses, so a real corpus can
   // never end up showing a previous (fixture) corpus's stale hits.
   const kwicReqRef = useRef(0);
-  const fetchKwic = useCallback((corpus: CorpusMeta | null, q: string, lyr: QueryLayer) => {
-    if (!corpus || !q.trim()) {
-      setResult(null);
-      setLoading(false);
-      return;
-    }
-    const myId = ++kwicReqRef.current;
-    setLoading(true);
-    // Fixture corpora (or non-Tauri preview) use the baked-in demo hits.
-    if (!inTauri() || isFixtureCorpus(corpus.id)) {
-      const hits = pickHits(corpus.id, q.trim(), lyr);
-      if (myId === kwicReqRef.current) {
-        setResult({ hits, elapsedMs: 0.2 + Math.random() * 1.6, truncated: hits.length >= 1000 });
-        setSelected(null);
+  const fetchKwic = useCallback(
+    (corpus: CorpusMeta | null, q: string, lyr: QueryLayer, offset: number) => {
+      if (!corpus || !q.trim()) {
+        setResult(null);
         setLoading(false);
+        return;
       }
-      return;
-    }
-    runKwicTauri({ corpusId: corpus.id, term: q.trim(), layer: lyr, context: 8, limit: 200 })
-      .then((r) => {
-        if (myId !== kwicReqRef.current) return;
-        const hits: KwicHit[] = r.hits.map((h, i) => ({
-          docId: String(h.docId),
-          pos: i,
-          hitPos: h.hitPosition,
-          left: h.left,
-          hit: h.hit,
-          right: h.right,
-        }));
-        setResult({ hits, elapsedMs: r.elapsedMs, truncated: r.truncated });
-        setSelected(null);
-      })
-      .catch((e) => {
-        if (myId !== kwicReqRef.current) return;
-        console.error("runKwic failed:", e);
-        setResult({ hits: [], elapsedMs: 0, truncated: false });
-        setSelected(null);
-      })
-      .finally(() => {
-        if (myId === kwicReqRef.current) setLoading(false);
-      });
-  }, []);
+      const myId = ++kwicReqRef.current;
+      setLoading(true);
+      // Fixture corpora (or non-Tauri preview) use the baked-in demo hits.
+      if (!inTauri() || isFixtureCorpus(corpus.id)) {
+        const hits = pickHits(corpus.id, q.trim(), lyr);
+        if (myId === kwicReqRef.current) {
+          setResult({ hits, elapsedMs: 0.2 + Math.random() * 1.6, truncated: false, total: hits.length, offset: 0 });
+          setSelected(null);
+          setLoading(false);
+        }
+        return;
+      }
+      runKwicTauri({ corpusId: corpus.id, term: q.trim(), layer: lyr, context: 8, limit: KWIC_PAGE, offset })
+        .then((r) => {
+          if (myId !== kwicReqRef.current) return;
+          const hits: KwicHit[] = r.hits.map((h, i) => ({
+            docId: String(h.docId),
+            pos: i,
+            hitPos: h.hitPosition,
+            left: h.left,
+            hit: h.hit,
+            right: h.right,
+          }));
+          setResult({ hits, elapsedMs: r.elapsedMs, truncated: r.truncated, total: r.total, offset: r.offset });
+          setSelected(null);
+        })
+        .catch((e) => {
+          if (myId !== kwicReqRef.current) return;
+          console.error("runKwic failed:", e);
+          setResult({ hits: [], elapsedMs: 0, truncated: false, total: 0, offset: 0 });
+          setSelected(null);
+        })
+        .finally(() => {
+          if (myId === kwicReqRef.current) setLoading(false);
+        });
+    },
+    [],
+  );
 
-  // Auto-fetch on corpus / term / layer change (debounced so typing
-  // coalesces). The guard inside drops stale responses.
+  // Auto-fetch on corpus / term / layer change — always resets to the
+  // first page (debounced so typing coalesces). The guard drops stale
+  // responses.
   useEffect(() => {
-    const t = window.setTimeout(() => fetchKwic(activeCorpus, term, layer), 100);
+    const t = window.setTimeout(() => fetchKwic(activeCorpus, term, layer, 0), 100);
     return () => window.clearTimeout(t);
   }, [activeCorpus, term, layer, fetchKwic]);
 
-  // Explicit Enter / "Run" — fetch immediately, no debounce.
-  const run = () => fetchKwic(activeCorpus, term, layer);
+  // Jump to a concordance page (offset in hits) — fetches immediately.
+  const goToPage = (offset: number) => fetchKwic(activeCorpus, term, layer, offset);
+
+  // Explicit Enter / "Run" — fetch the first page immediately.
+  const run = () => fetchKwic(activeCorpus, term, layer, 0);
 
   // Fetch real collocates when the Collocations view is active on a
   // real (backend-registered) corpus. Fixture corpora keep whatever
@@ -379,6 +389,8 @@ export function App() {
                 onSort={onSortChange}
                 selected={selected}
                 onSelect={setSelected}
+                pageSize={KWIC_PAGE}
+                onPage={goToPage}
               />
               <HitDensityGutter density={density} scrollPct={scrollPct} onJump={() => {}} />
               {selected && activeCorpus && (

--- a/app/src/components/chrome/StatusBar.tsx
+++ b/app/src/components/chrome/StatusBar.tsx
@@ -42,22 +42,11 @@ export function StatusBar({ corpus, result, layer, memory = 0.42 }: StatusBarPro
         {result && (
           <>
             <span className="cx-sep">·</span>
-            <span>{result.hits.length.toLocaleString()} hits</span>
+            <span>{result.total.toLocaleString()} hits</span>
             <span className="cx-sep">·</span>
             <span className={`cx-layer-chip cx-layer-${layer}`}>{layer}</span>
             <span className="cx-sep">·</span>
             <span className="cx-status-time">{formatDuration(result.elapsedMs)}</span>
-            {result.truncated && (
-              <>
-                <span className="cx-sep">·</span>
-                <span
-                  className="cx-status-dim"
-                  title={`More matches exist than the ${result.hits.length.toLocaleString()}-line display cap; showing the first ${result.hits.length.toLocaleString()}. Frequency and collocation stats still use the whole corpus.`}
-                >
-                  first {result.hits.length.toLocaleString()} shown
-                </span>
-              </>
-            )}
           </>
         )}
       </div>

--- a/app/src/components/chrome/ViewTabs.test.tsx
+++ b/app/src/components/chrome/ViewTabs.test.tsx
@@ -10,6 +10,8 @@ const result: KwicResult = {
   ],
   elapsedMs: 0,
   truncated: false,
+  total: 2,
+  offset: 0,
 };
 
 describe("ViewTabs", () => {

--- a/app/src/components/chrome/ViewTabs.tsx
+++ b/app/src/components/chrome/ViewTabs.tsx
@@ -14,7 +14,7 @@ export function ViewTabs({ view, onView, result }: ViewTabsProps) {
     Icon: typeof Table2;
     count: number | null;
   }[] = [
-    { id: "kwic", label: "concordance", Icon: Table2, count: result ? result.hits.length : null },
+    { id: "kwic", label: "concordance", Icon: Table2, count: result ? result.total : null },
     { id: "coll", label: "collocations", Icon: Network, count: null },
     { id: "freq", label: "frequency", Icon: BarChart3, count: null },
     { id: "tree", label: "word tree", Icon: ListTree, count: null },

--- a/app/src/components/kwic/KwicTable.tsx
+++ b/app/src/components/kwic/KwicTable.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowUp, Download } from "lucide-react";
+import { ArrowDown, ArrowUp, ChevronLeft, ChevronRight, Download } from "lucide-react";
 import { useMemo } from "react";
 import type { KwicHit, KwicResult, QueryLayer, SortDir, SortMode } from "@/types";
 import { formatDuration } from "@/lib/utils";
@@ -15,6 +15,10 @@ export interface KwicTableProps {
   onSort: (mode: SortMode) => void;
   selected: KwicHit | null;
   onSelect: (h: KwicHit) => void;
+  /** Hits per page. */
+  pageSize: number;
+  /** Jump to a page (offset in hits). */
+  onPage: (offset: number) => void;
 }
 
 function sortHits(hits: KwicHit[], mode: SortMode, dir: SortDir): KwicHit[] {
@@ -41,6 +45,8 @@ export function KwicTable({
   onSort,
   selected,
   onSelect,
+  pageSize,
+  onPage,
 }: KwicTableProps) {
   const sortedHits = useMemo(
     () => (result ? sortHits(result.hits, sortMode, sortDir) : []),
@@ -103,7 +109,28 @@ export function KwicTable({
           );
         })}
         <span className="sep">·</span>
-        <span>{result.hits.length.toLocaleString()} hits</span>
+        <span>
+          {(result.total === 0 ? 0 : result.offset + 1).toLocaleString()}–
+          {(result.offset + result.hits.length).toLocaleString()} of {result.total.toLocaleString()}
+        </span>
+        <button
+          type="button"
+          className="cx-sort-btn"
+          disabled={result.offset === 0}
+          onClick={() => onPage(Math.max(0, result.offset - pageSize))}
+          title="previous page"
+        >
+          <ChevronLeft size={12} />
+        </button>
+        <button
+          type="button"
+          className="cx-sort-btn"
+          disabled={result.offset + result.hits.length >= result.total}
+          onClick={() => onPage(result.offset + pageSize)}
+          title="next page"
+        >
+          <ChevronRight size={12} />
+        </button>
         <span className="sep">·</span>
         <span className="cx-status-time">{formatDuration(result.elapsedMs)}</span>
         <span className="cx-spacer" />

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -50,6 +50,8 @@ export interface KwicResultRaw {
   hits: KwicHitRaw[];
   elapsedMs: number;
   truncated: boolean;
+  total: number;
+  offset: number;
 }
 
 export interface DocumentInfo {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -30,6 +30,8 @@ export interface KwicRequest {
   layer: QueryLayer;
   context: number;
   limit: number;
+  /** Hits to skip before this page (concordance pagination). */
+  offset?: number;
 }
 
 export interface KwicHit {
@@ -50,6 +52,10 @@ export interface KwicResult {
   hits: KwicHit[];
   elapsedMs: number;
   truncated: boolean;
+  /** Total matches across the corpus (paging denominator). */
+  total: number;
+  /** 0-based index of the first hit in this page. */
+  offset: number;
 }
 
 export interface ExpandedHit {

--- a/crates/corpust-cli/src/main.rs
+++ b/crates/corpust-cli/src/main.rs
@@ -409,13 +409,14 @@ fn run_kwic(
         .with_context(|| format!("opening index at {}", index_path.display()))?;
 
     let t0 = Instant::now();
-    let hits = kwic(
+    let page = kwic(
         &index,
         KwicRequest::new(term)
             .layer(layer)
             .context(context)
             .limit(limit),
     )?;
+    let hits = &page.hits;
     let elapsed = t0.elapsed();
 
     let left_width = hits
@@ -429,7 +430,7 @@ fn run_kwic(
         .max()
         .unwrap_or(0);
 
-    for hit in &hits {
+    for hit in hits {
         let file = hit.path.file_name().and_then(|s| s.to_str()).unwrap_or("?");
         println!(
             "{file:20} | {left:>lw$}  \x1b[1m{hit:^hw$}\x1b[0m  {right}",
@@ -441,6 +442,11 @@ fn run_kwic(
             hw = hit_width,
         );
     }
-    println!("\n{} hit(s) in {:.2?}", hits.len(), elapsed);
+    println!(
+        "\nshowing {} of {} hit(s) in {:.2?}",
+        hits.len(),
+        page.total,
+        elapsed
+    );
     Ok(())
 }

--- a/crates/corpust-index/src/lib.rs
+++ b/crates/corpust-index/src/lib.rs
@@ -121,6 +121,15 @@ pub struct KwicHit {
     pub right: String,
 }
 
+/// A page of concordance lines plus the total match count, so callers can
+/// paginate ("showing 1–200 of 12,431").
+#[derive(Debug, Clone)]
+pub struct KwicPage {
+    pub hits: Vec<KwicHit>,
+    /// Total occurrences of the term on the layer (the paging denominator).
+    pub total: usize,
+}
+
 /// One document's summary, for the corpus document list.
 #[derive(Debug, Clone)]
 pub struct DocumentInfo {
@@ -456,7 +465,8 @@ impl CorpusIndex {
         layer: QueryLayer,
         context: usize,
         limit: usize,
-    ) -> Result<Vec<KwicHit>> {
+        offset: usize,
+    ) -> Result<KwicPage> {
         let searcher = self.reader.searcher();
         let (query_field, lookup_term) = match layer {
             QueryLayer::Word => (self.fields.body, term.to_lowercase()),
@@ -465,13 +475,17 @@ impl CorpusIndex {
         };
         let term_obj = Term::from_field_text(query_field, &lookup_term);
 
-        let mut hits = Vec::with_capacity(limit);
+        // Hits are globally ordered by (segment, doc, position). We walk
+        // every posting to count the grand total (cheap — `term_freq` per
+        // doc, no positions needed) but only fetch the document + build
+        // windows for the docs whose hit range intersects the requested
+        // page `[offset, offset + limit)`.
+        let page_end = offset.saturating_add(limit);
+        let mut hits = Vec::with_capacity(limit.min(512));
+        let mut total: usize = 0;
         let mut positions_buf: Vec<u32> = Vec::new();
 
         'segments: for (seg_ord, seg_reader) in searcher.segment_readers().iter().enumerate() {
-            if hits.len() >= limit {
-                break;
-            }
             let inv_idx = seg_reader.inverted_index(query_field)?;
             let Some(mut postings) =
                 inv_idx.read_postings(&term_obj, IndexRecordOption::WithFreqsAndPositions)?
@@ -484,57 +498,62 @@ impl CorpusIndex {
                 if doc == TERMINATED {
                     continue 'segments;
                 }
-                if hits.len() >= limit {
-                    break 'segments;
-                }
+                let tf = postings.term_freq() as usize;
+                let doc_start = total;
+                total += tf;
 
-                let doc_addr = DocAddress::new(seg_ord as u32, doc);
-                let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
-                let body = retrieved
-                    .get_first(self.fields.body)
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default();
-                let path = retrieved
-                    .get_first(self.fields.path)
-                    .and_then(|v| v.as_str())
-                    .unwrap_or_default();
-                let doc_id = retrieved
-                    .get_first(self.fields.doc_id)
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0);
-                let offsets_bytes = retrieved
-                    .get_first(self.fields.token_offsets)
-                    .and_then(|v| v.as_bytes())
-                    .unwrap_or_default();
-                let offsets = bytes_to_offsets(offsets_bytes);
+                // Build hits only for docs overlapping the page window.
+                if doc_start < page_end && total > offset {
+                    let doc_addr = DocAddress::new(seg_ord as u32, doc);
+                    let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
+                    let body = retrieved
+                        .get_first(self.fields.body)
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    let path = retrieved
+                        .get_first(self.fields.path)
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    let doc_id = retrieved
+                        .get_first(self.fields.doc_id)
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    let offsets = bytes_to_offsets(
+                        retrieved
+                            .get_first(self.fields.token_offsets)
+                            .and_then(|v| v.as_bytes())
+                            .unwrap_or_default(),
+                    );
 
-                positions_buf.clear();
-                postings.positions(&mut positions_buf);
-
-                for &pos in &positions_buf {
-                    if hits.len() >= limit {
-                        break;
+                    positions_buf.clear();
+                    postings.positions(&mut positions_buf);
+                    for (k, &pos) in positions_buf.iter().enumerate() {
+                        let gi = doc_start + k; // global hit index
+                        if gi < offset {
+                            continue;
+                        }
+                        if gi >= page_end {
+                            break;
+                        }
+                        let p = pos as usize;
+                        if let Some((left, hit, right)) = window(body, &offsets, p, context) {
+                            hits.push(KwicHit {
+                                doc_id,
+                                path: PathBuf::from(path),
+                                hit_position: p,
+                                left,
+                                hit,
+                                right,
+                            });
+                        }
                     }
-                    let p = pos as usize;
-                    let Some((left, hit, right)) = window(body, &offsets, p, context) else {
-                        continue;
-                    };
-
-                    hits.push(KwicHit {
-                        doc_id,
-                        path: PathBuf::from(path),
-                        hit_position: p,
-                        left,
-                        hit,
-                        right,
-                    });
                 }
 
                 postings.advance();
             }
         }
 
-        Ok(hits)
+        Ok(KwicPage { hits, total })
     }
 
     /// Re-extract the concordance window around a known hit position in a
@@ -1568,7 +1587,7 @@ mod tests {
         )
         .unwrap();
 
-        let hits = idx.kwic("the", QueryLayer::Word, 2, 10).unwrap();
+        let hits = idx.kwic("the", QueryLayer::Word, 2, 10, 0).unwrap().hits;
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].hit, "the");
         let _ = std::fs::remove_dir_all(&tmp);
@@ -1588,7 +1607,7 @@ mod tests {
         )
         .unwrap();
 
-        let hits = idx.kwic("the", QueryLayer::Word, 1, 10).unwrap();
+        let hits = idx.kwic("the", QueryLayer::Word, 1, 10, 0).unwrap().hits;
         assert_eq!(hits.len(), 2);
         assert!(hits.iter().any(|h| h.hit == "The"));
         assert!(hits.iter().any(|h| h.hit == "THE"));
@@ -1609,7 +1628,7 @@ mod tests {
         )
         .unwrap();
 
-        let hits = idx.kwic("target", QueryLayer::Word, 2, 10).unwrap();
+        let hits = idx.kwic("target", QueryLayer::Word, 2, 10, 0).unwrap().hits;
         assert_eq!(hits.len(), 1);
         let h = &hits[0];
         assert_eq!(h.left, "gamma delta");
@@ -1632,7 +1651,10 @@ mod tests {
         )
         .unwrap();
 
-        let hits = idx.kwic("target", QueryLayer::Word, 10, 10).unwrap();
+        let hits = idx
+            .kwic("target", QueryLayer::Word, 10, 10, 0)
+            .unwrap()
+            .hits;
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].left, "");
         assert_eq!(hits[0].right, "one two three");
@@ -1655,7 +1677,7 @@ mod tests {
         )
         .unwrap();
 
-        let hits = idx.kwic("quick", QueryLayer::Word, 1, 10).unwrap();
+        let hits = idx.kwic("quick", QueryLayer::Word, 1, 10, 0).unwrap().hits;
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].hit, "quick");
         assert_eq!(hits[0].left, "the");
@@ -1663,9 +1685,9 @@ mod tests {
 
         // WordOnly emits empty lemma / pos tokens — queries on those
         // layers find nothing.
-        let no_lemma = idx.kwic("quick", QueryLayer::Lemma, 1, 10).unwrap();
+        let no_lemma = idx.kwic("quick", QueryLayer::Lemma, 1, 10, 0).unwrap().hits;
         assert!(no_lemma.is_empty());
-        let no_pos = idx.kwic("NN", QueryLayer::Pos, 1, 10).unwrap();
+        let no_pos = idx.kwic("NN", QueryLayer::Pos, 1, 10, 0).unwrap().hits;
         assert!(no_pos.is_empty());
 
         let _ = std::fs::remove_dir_all(&tmp);
@@ -1812,7 +1834,7 @@ mod tests {
     fn context_at_reexpands_window() {
         let (tmp, idx) = two_doc_index();
         // Locate a hit first, then re-expand it wider.
-        let hits = idx.kwic("sat", QueryLayer::Word, 1, 10).unwrap();
+        let hits = idx.kwic("sat", QueryLayer::Word, 1, 10, 0).unwrap().hits;
         assert_eq!(hits.len(), 1);
         let h = &hits[0];
         assert_eq!(h.left, "cat");

--- a/crates/corpust-query/src/lib.rs
+++ b/crates/corpust-query/src/lib.rs
@@ -6,7 +6,7 @@
 //! callers' import paths.
 
 use anyhow::Result;
-use corpust_index::{CorpusIndex, DEFAULT_CONTEXT, DEFAULT_LIMIT, KwicHit, QueryLayer};
+use corpust_index::{CorpusIndex, DEFAULT_CONTEXT, DEFAULT_LIMIT, KwicPage, QueryLayer};
 
 pub use corpust_index::QueryLayer as Layer;
 
@@ -17,6 +17,8 @@ pub struct KwicRequest<'a> {
     pub layer: QueryLayer,
     pub context: usize,
     pub limit: usize,
+    /// Hits to skip before the page — for concordance pagination.
+    pub offset: usize,
 }
 
 impl<'a> KwicRequest<'a> {
@@ -26,6 +28,7 @@ impl<'a> KwicRequest<'a> {
             layer: QueryLayer::Word,
             context: DEFAULT_CONTEXT,
             limit: DEFAULT_LIMIT,
+            offset: 0,
         }
     }
 
@@ -43,10 +46,21 @@ impl<'a> KwicRequest<'a> {
         self.limit = limit;
         self
     }
+
+    pub fn offset(mut self, offset: usize) -> Self {
+        self.offset = offset;
+        self
+    }
 }
 
-pub fn kwic(index: &CorpusIndex, request: KwicRequest<'_>) -> Result<Vec<KwicHit>> {
-    index.kwic(request.term, request.layer, request.context, request.limit)
+pub fn kwic(index: &CorpusIndex, request: KwicRequest<'_>) -> Result<KwicPage> {
+    index.kwic(
+        request.term,
+        request.layer,
+        request.context,
+        request.limit,
+        request.offset,
+    )
 }
 
 #[cfg(test)]
@@ -93,8 +107,22 @@ mod tests {
     #[test]
     fn kwic_facade_returns_index_hits() {
         let (_tmp, idx) = tiny_index();
-        let hits = kwic(&idx, KwicRequest::new("the").context(2).limit(10)).unwrap();
-        assert_eq!(hits.len(), 2);
-        assert!(hits.iter().all(|h| h.hit == "the"));
+        let page = kwic(&idx, KwicRequest::new("the").context(2).limit(10)).unwrap();
+        assert_eq!(page.total, 2);
+        assert_eq!(page.hits.len(), 2);
+        assert!(page.hits.iter().all(|h| h.hit == "the"));
+    }
+
+    #[test]
+    fn kwic_facade_paginates() {
+        let (_tmp, idx) = tiny_index();
+        // "the" occurs twice; page size 1 yields one hit per page, total 2.
+        let p0 = kwic(&idx, KwicRequest::new("the").context(2).limit(1).offset(0)).unwrap();
+        assert_eq!(p0.total, 2);
+        assert_eq!(p0.hits.len(), 1);
+        let p1 = kwic(&idx, KwicRequest::new("the").context(2).limit(1).offset(1)).unwrap();
+        assert_eq!(p1.total, 2);
+        assert_eq!(p1.hits.len(), 1);
+        assert_ne!(p0.hits[0].hit_position, p1.hits[0].hit_position);
     }
 }


### PR DESCRIPTION
Closes #32.

KWIC fetched a fixed first 200 lines, leaving the rest of the matches inaccessible for frequent terms.

## Backend
- `CorpusIndex::kwic` gains an `offset` and returns `KwicPage { hits, total }`. It walks all postings to count the grand total cheaply (`term_freq` per doc — no position decode) but only fetches the document + builds windows for docs overlapping the page window `[offset, offset+limit)`.
- `corpust-query` façade + CLI thread `offset` through; the CLI now prints "showing N of total".
- `run_kwic`: `KwicRequest` gains `offset`; `KwicResult` gains `total` + `offset`.

## Frontend
- One paged fetch path: term/layer/corpus changes always reset to page 0; `goToPage` handles explicit nav.
- `KwicTable` shows **"N–M of total"** with prev/next page buttons.
- Status bar and the concordance tab badge now show the real **total** (not the page size).

## Notes / limitation
- Column sort currently sorts **within the visible page** (whole-corpus ordering would need a backend ORDER BY) — fine for now; can be a follow-up.

## Verification
`cargo clippy --workspace` + `fmt` clean; index 25 / query 4 (incl. new `kwic_facade_paginates`) / cli 7 + 55 frontend tests green.