### PR TITLE
Correct stale ~92% tagger accuracy label → ~99%

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -192,7 +192,8 @@ pub struct BuildRequest {
 #[serde(rename_all = "lowercase")]
 pub enum TaggerKind {
     /// Pure-Rust in-process TreeTagger port. Fast (~2.5× end-to-end
-    /// speedup over subprocess) but currently ~92% POS accuracy.
+    /// speedup over subprocess) at ~99% POS accuracy (98.8–99.8% across
+    /// the Gutenberg / UNSC samples).
     #[default]
     Rust,
     /// Bundled `tree-tagger` binary; one subprocess per document.

--- a/app/src/components/overlays/BuildDialog.tsx
+++ b/app/src/components/overlays/BuildDialog.tsx
@@ -304,7 +304,7 @@ export function BuildDialog({ open, onClose, onBuilt }: BuildDialogProps) {
                   disabled={phase !== "idle"}
                 />
                 <span>
-                  pure-Rust<span className="sub"> · in-process, ~92% POS</span>
+                  pure-Rust<span className="sub"> · in-process, ~99% POS</span>
                 </span>
               </label>
               <label className="cx-checkbox">

--- a/crates/corpust-cli/src/main.rs
+++ b/crates/corpust-cli/src/main.rs
@@ -22,9 +22,9 @@ enum TaggerArg {
     /// parity) but slow.
     Subprocess,
     /// Pure-Rust in-process tagger (`corpust-tagger::Tagger`).
-    /// ~200× faster per call, currently at ~92% POS accuracy
-    /// because dtree Viterbi hasn't landed. Use for indexing where
-    /// throughput matters more than exact parity.
+    /// ~200× faster per call at ~99% POS accuracy (98.8–99.8% across the
+    /// Gutenberg / UNSC samples). Use for indexing where throughput
+    /// matters more than exact reference parity.
     Rust,
 }
 


### PR DESCRIPTION
The build dialog showed "pure-Rust · in-process, ~92% POS", which is stale — the pure-Rust tagger has been at **98.8–99.8% POS** (README parity table) since the case-insensitive lex merge (#15). The 92% figure (and a "Viterbi hasn't landed" comment) predated that work.

- `BuildDialog.tsx`: label → "~99% POS".
- `TaggerKind` doc comments (Tauri `lib.rs` + CLI `main.rs`): updated to ~99% (98.8–99.8%) and dropped the obsolete Viterbi note.

Spotted in-app. See also #44 (where the residual gap concentrates).