### PR TITLE
Replace dummy controls with real data; drop fake meters

### DIFF
--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:default",
     "dialog:default",
-    "opener:default"
+    "dialog:allow-save",
+    "opener:default",
+    "opener:allow-reveal-item-in-dir"
   ]
 }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1021,6 +1021,21 @@ fn resolve_treetagger_bundle_root(app: &AppHandle) -> Result<PathBuf, String> {
     ))
 }
 
+/// Write a UTF-8 string to `path`, creating or truncating the file.
+///
+/// Backs the frontend's export actions: the UI builds the CSV/JSON text
+/// and picks a destination with the save dialog, then hands both here so
+/// the bytes land on disk. Kept deliberately minimal — no directory
+/// creation, no appends.
+#[tauri::command]
+pub async fn write_text_file(path: String, contents: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        std::fs::write(&path, contents).map_err(|e| format!("write {path}: {e}"))
+    })
+    .await
+    .map_err(|e| format!("write task panicked: {e}"))?
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,10 +1,8 @@
 //! Tauri backend for the corpust desktop app.
 //!
 //! Thin command layer over `corpust-query` + `corpust-index`. The React
-//! frontend calls these via `@tauri-apps/api::invoke`. Everything below
-//! is intentionally stub-heavy right now — the visual shape of the UI
-//! comes first; command bodies get fleshed out once the layout is
-//! locked in.
+//! frontend calls these via `@tauri-apps/api::invoke`; the command
+//! bodies live in `commands.rs` and drive the real index / query crates.
 
 use corpust_index::CorpusIndex;
 use serde::{Deserialize, Serialize};
@@ -56,6 +54,7 @@ pub fn run() {
             commands::run_term_distribution,
             commands::run_collocate_distance,
             commands::expand_context,
+            commands::write_text_file,
         ])
         .run(tauri::generate_context!())
         .expect("error while running corpust");

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,15 +1,14 @@
 // Top-level composition. Holds all view / corpus / query / overlay state.
-// TODO: replace in-memory `corpora` and `pickHits` with Tauri IPC —
-//   listCorpora()  → corpora
-//   runKwic(req)   → result
-//   buildIndex(…)  → stream progress into BuildDialog
+// Real corpora are served over Tauri IPC (listCorpora / runKwic /
+// buildIndex …); the baked-in `@/data` fixtures are the fallback shown
+// when no real corpus is loaded (vite preview or the demo set).
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Sidebar } from "@/components/chrome/Sidebar";
 import { StatusBar } from "@/components/chrome/StatusBar";
 import { TitleStrip } from "@/components/chrome/TitleStrip";
 import { ViewTabs } from "@/components/chrome/ViewTabs";
-import { QueryBar, type Filter } from "@/components/query/QueryBar";
+import { QueryBar } from "@/components/query/QueryBar";
 import { KwicTable } from "@/components/kwic/KwicTable";
 import { HitDensityGutter } from "@/components/kwic/HitDensityGutter";
 import { ContextDrawer } from "@/components/kwic/ContextDrawer";
@@ -24,6 +23,7 @@ import { Onboarding } from "@/components/analyses/Onboarding";
 import { CommandPalette, type CommandDef } from "@/components/overlays/CommandPalette";
 import { BuildDialog } from "@/components/overlays/BuildDialog";
 import { CORPORA, RECENT_QUERIES, pickHits } from "@/data";
+import { concordanceCsv, concordanceJson, saveText, slug } from "@/lib/export";
 import { makeDensity } from "@/lib/utils";
 import { inTauri, isFixtureCorpus, listCorpora, runCollocates, runKwic as runKwicTauri } from "@/lib/tauri";
 import type { Collocate } from "@/types";
@@ -71,8 +71,11 @@ export function App() {
   );
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [buildOpen, setBuildOpen] = useState(false);
-  const [filters, setFilters] = useState<Filter[]>([{ key: "year", label: "year: 1800–1950" }]);
-  const scrollPct = 0.18;
+  // Concordance scroll position (0–1), tracked from the KWIC column so the
+  // hit-density gutter's thumb reflects where you actually are, and clicks
+  // on the gutter scroll there.
+  const kwicScrollRef = useRef<HTMLDivElement>(null);
+  const [scrollPct, setScrollPct] = useState(0);
 
   // Refresh the corpora list from disk via the Tauri backend. Real
   // (persisted) corpora land at the top; baked-in fixtures stay below
@@ -181,6 +184,43 @@ export function App() {
   // Explicit Enter / "Run" — fetch the first page immediately.
   const run = () => fetchKwic(activeCorpus, term, layer, 0);
 
+  // Keep `scrollPct` in sync with the concordance column so the density
+  // gutter's thumb tracks the real scroll position. Re-attaches whenever
+  // the table remounts (result/subview change swap the scroll element).
+  useEffect(() => {
+    const el = kwicScrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const max = el.scrollHeight - el.clientHeight;
+      setScrollPct(max > 0 ? el.scrollTop / max : 0);
+    };
+    onScroll();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [result, subview, view]);
+
+  // Click on the density gutter → scroll the concordance to that fraction.
+  const onDensityJump = (pct: number) => {
+    const el = kwicScrollRef.current;
+    if (!el) return;
+    el.scrollTo({ top: pct * (el.scrollHeight - el.clientHeight), behavior: "smooth" });
+  };
+
+  // Export the current concordance page. CSV is flat (n, doc, position,
+  // left, node, right); JSON carries the query context + any lemma/POS.
+  const exportConcordance = useCallback(
+    (format: "csv" | "json") => {
+      if (!result || result.hits.length === 0) return;
+      const base = `${slug(activeCorpus?.name ?? "concordance")}-${slug(term || "query")}`;
+      if (format === "csv") {
+        void saveText(`${base}.csv`, concordanceCsv(result), "text/csv");
+      } else {
+        void saveText(`${base}.json`, concordanceJson(result, activeCorpus, term, layer), "application/json");
+      }
+    },
+    [result, activeCorpus, term, layer],
+  );
+
   // Fetch real collocates when the Collocations view is active on a
   // real (backend-registered) corpus. Fixture corpora keep whatever
   // data.ts ships.
@@ -263,6 +303,9 @@ export function App() {
       } else if (meta && e.key === "3") {
         e.preventDefault();
         if (activeCorpus?.annotated) setLayer("pos");
+      } else if (meta && e.key.toLowerCase() === "e") {
+        e.preventDefault();
+        exportConcordance("csv");
       } else if (e.key === "Escape") {
         setSelected(null);
       } else if ((e.key === "j" || e.key === "k") && result && !paletteOpen && !buildOpen) {
@@ -280,7 +323,7 @@ export function App() {
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [activeCorpus, result, selected, paletteOpen, buildOpen]);
+  }, [activeCorpus, result, selected, paletteOpen, buildOpen, exportConcordance]);
 
   const runRecent = (q: RecentQuery) => {
     setLayer(q.layer);
@@ -318,6 +361,10 @@ export function App() {
     } else if (cmd.id === "view-freq") {
       setView("search");
       setSubview("freq");
+    } else if (cmd.id === "export-csv") {
+      exportConcordance("csv");
+    } else if (cmd.id === "export-json") {
+      exportConcordance("json");
     }
   };
 
@@ -374,8 +421,6 @@ export function App() {
           disabled={!activeCorpus}
           annotated={!!activeCorpus?.annotated}
           onOpenPalette={() => setPaletteOpen(true)}
-          filters={filters}
-          onRemoveFilter={(k) => setFilters((fs) => fs.filter((f) => f.key !== k))}
         />
         <ViewTabs view={subview} onView={setSubview} result={result} />
         <div className="cx-results-wrap">
@@ -392,8 +437,10 @@ export function App() {
                 onSelect={setSelected}
                 pageSize={KWIC_PAGE}
                 onPage={goToPage}
+                onExport={exportConcordance}
+                scrollRef={kwicScrollRef}
               />
-              <HitDensityGutter density={density} scrollPct={scrollPct} onJump={() => {}} />
+              <HitDensityGutter density={density} scrollPct={scrollPct} onJump={onDensityJump} />
               {selected && activeCorpus && (
                 <ContextDrawer
                   hit={selected}
@@ -460,7 +507,6 @@ export function App() {
             corpus={activeCorpus}
             result={view === "search" ? result : null}
             layer={layer}
-            memory={0.42}
           />
         </main>
       </div>

--- a/app/src/components/analyses/CorpusDetail.tsx
+++ b/app/src/components/analyses/CorpusDetail.tsx
@@ -1,6 +1,8 @@
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { Download, Eye, Search } from "lucide-react";
 import { useEffect, useState } from "react";
 import { DOCUMENTS } from "@/data";
+import { documentsCsv, saveText, slug } from "@/lib/export";
 import { type DocumentInfo, hasLiveData, listDocuments } from "@/lib/tauri";
 import type { CorpusMeta } from "@/types";
 import { basename, formatBuildTime, formatBytes, formatDate } from "@/lib/utils";
@@ -68,6 +70,18 @@ export function CorpusDetail({ corpus, onDismiss }: CorpusDetailProps) {
         year: d.year ?? null,
         tokens: d.tokens,
       }));
+
+  // Reveal the built index folder in the OS file manager. Only meaningful
+  // for real corpora — fixtures carry a placeholder `~/corpora/…` path.
+  const onReveal = () => {
+    if (!isLive) return;
+    void revealItemInDir(corpus.indexPath).catch((e) => console.error("reveal failed:", e));
+  };
+  // Export the document table as CSV (works for fixtures and live alike).
+  const onExportDocs = () => {
+    void saveText(`${slug(corpus.name)}-documents.csv`, documentsCsv(docRows), "text/csv");
+  };
+
   return (
     <div className="cx-detail">
       <div className="cx-detail-head">
@@ -77,11 +91,17 @@ export function CorpusDetail({ corpus, onDismiss }: CorpusDetailProps) {
           <div className="cx-detail-sub">{corpus.indexPath}</div>
         </div>
         <div className="cx-detail-actions">
-          <button type="button" className="cx-btn cx-btn-outline">
+          <button
+            type="button"
+            className="cx-btn cx-btn-outline"
+            onClick={onReveal}
+            disabled={!isLive}
+            title={isLive ? "Reveal the index folder" : "Available once the corpus is built"}
+          >
             <Eye size={13} />
             reveal
           </button>
-          <button type="button" className="cx-btn cx-btn-outline">
+          <button type="button" className="cx-btn cx-btn-outline" onClick={onExportDocs} title="Export the document list as CSV">
             <Download size={13} />
             export
           </button>

--- a/app/src/components/chrome/StatusBar.tsx
+++ b/app/src/components/chrome/StatusBar.tsx
@@ -5,10 +5,9 @@ export interface StatusBarProps {
   corpus: CorpusMeta | null;
   result: KwicResult | null;
   layer: QueryLayer;
-  memory?: number;
 }
 
-export function StatusBar({ corpus, result, layer, memory = 0.42 }: StatusBarProps) {
+export function StatusBar({ corpus, result, layer }: StatusBarProps) {
   return (
     <div className="cx-statusbar">
       <div className="cx-statusbar-left">
@@ -32,16 +31,8 @@ export function StatusBar({ corpus, result, layer, memory = 0.42 }: StatusBarPro
         )}
       </div>
       <div className="cx-statusbar-right">
-        <span className="cx-status-mem" title="memory">
-          mem
-          <span className="cx-status-mem-bar">
-            <span style={{ display: "block", height: "100%", width: `${memory * 100}%`, background: "var(--fg-subtle)" }} />
-          </span>
-          {Math.round(memory * 100)}%
-        </span>
         {result && (
           <>
-            <span className="cx-sep">·</span>
             <span>{result.total.toLocaleString()} hits</span>
             <span className="cx-sep">·</span>
             <span className={`cx-layer-chip cx-layer-${layer}`}>{layer}</span>

--- a/app/src/components/kwic/KwicTable.tsx
+++ b/app/src/components/kwic/KwicTable.tsx
@@ -1,5 +1,5 @@
 import { ArrowDown, ArrowUp, ChevronLeft, ChevronRight, Download } from "lucide-react";
-import { useMemo } from "react";
+import { type Ref, useMemo } from "react";
 import type { KwicHit, KwicResult, QueryLayer, SortDir, SortMode } from "@/types";
 import { formatDuration } from "@/lib/utils";
 
@@ -19,6 +19,11 @@ export interface KwicTableProps {
   pageSize: number;
   /** Jump to a page (offset in hits). */
   onPage: (offset: number) => void;
+  /** Export the current page in the given format. */
+  onExport: (format: "csv" | "json") => void;
+  /** Ref to the scroll container, so the parent can track scroll
+   *  position (density gutter) and scroll to a fraction on jump. */
+  scrollRef?: Ref<HTMLDivElement>;
 }
 
 function sortHits(hits: KwicHit[], mode: SortMode, dir: SortDir): KwicHit[] {
@@ -47,6 +52,8 @@ export function KwicTable({
   onSelect,
   pageSize,
   onPage,
+  onExport,
+  scrollRef,
 }: KwicTableProps) {
   const sortedHits = useMemo(
     () => (result ? sortHits(result.hits, sortMode, sortDir) : []),
@@ -82,7 +89,7 @@ export function KwicTable({
   }
 
   return (
-    <div className="cx-kwic-col">
+    <div className="cx-kwic-col" ref={scrollRef}>
       <div className="cx-kwic-sort-bar">
         <span>sort</span>
         {(
@@ -134,7 +141,7 @@ export function KwicTable({
         <span className="sep">·</span>
         <span className="cx-status-time">{formatDuration(result.elapsedMs)}</span>
         <span className="cx-spacer" />
-        <button type="button" className="cx-sort-btn">
+        <button type="button" className="cx-sort-btn" onClick={() => onExport("csv")} title="Export this page as CSV">
           <Download size={11} /> export csv
         </button>
       </div>

--- a/app/src/components/query/QueryBar.tsx
+++ b/app/src/components/query/QueryBar.tsx
@@ -1,4 +1,4 @@
-import { Plus, Search, X } from "lucide-react";
+import { Search } from "lucide-react";
 import type { FormEvent } from "react";
 import type { QueryLayer } from "@/types";
 
@@ -7,11 +7,6 @@ const LAYERS: { value: QueryLayer; label: string; hint: string }[] = [
   { value: "lemma", label: "lemma", hint: "dictionary form · requires annotation" },
   { value: "pos", label: "pos", hint: "POS tag · case-sensitive (NN, VBD, …)" },
 ];
-
-export interface Filter {
-  key: string;
-  label: string;
-}
 
 export interface QueryBarProps {
   layer: QueryLayer;
@@ -22,8 +17,6 @@ export interface QueryBarProps {
   disabled?: boolean;
   annotated?: boolean;
   onOpenPalette: () => void;
-  filters: Filter[];
-  onRemoveFilter: (k: string) => void;
 }
 
 export function QueryBar({
@@ -35,8 +28,6 @@ export function QueryBar({
   disabled,
   annotated,
   onOpenPalette,
-  filters,
-  onRemoveFilter,
 }: QueryBarProps) {
   const submit = (e: FormEvent) => {
     e.preventDefault();
@@ -83,25 +74,6 @@ export function QueryBar({
         />
         <div className="cx-input-suffix">{term && <span>{layer === "pos" ? "exact" : "regex ok"}</span>}</div>
       </div>
-
-      {filters.map((f) => (
-        <span
-          key={f.key}
-          className="cx-filter-chip is-on"
-          onClick={() => onRemoveFilter(f.key)}
-          role="button"
-          tabIndex={0}
-        >
-          {f.label}
-          <span className="x">
-            <X size={10} />
-          </span>
-        </span>
-      ))}
-      <button type="button" className="cx-filter-chip" title="Add a metadata filter">
-        <Plus size={10} />
-        filter
-      </button>
 
       <button type="submit" className="cx-btn cx-btn-primary" disabled={disabled || !term.trim()}>
         Run

--- a/app/src/data.ts
+++ b/app/src/data.ts
@@ -1,6 +1,7 @@
-// Placeholder fixtures — will be replaced with Tauri IPC calls once the
-// backend commands in app/src-tauri/src/commands.rs are fleshed out.
-// Shape mirrors types.ts exactly.
+// Demo fixtures: the fallback dataset shown when no real corpus is loaded
+// (the vite-only preview, or the baked-in demo corpora). Real corpora are
+// served from the backend over Tauri IPC (see lib/tauri.ts). Shape mirrors
+// types.ts exactly.
 
 import type {
   Collocate,

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -584,10 +584,6 @@
 .cx-layer-chip.cx-layer-lemma { color: var(--layer-lemma); background: color-mix(in oklch, var(--layer-lemma) 18%, transparent); }
 .cx-layer-chip.cx-layer-pos { color: var(--layer-pos); background: color-mix(in oklch, var(--layer-pos) 22%, transparent); }
 
-.cx-status-mem { display: inline-flex; align-items: center; gap: 4px; }
-.cx-status-mem-bar { width: 30px; height: 4px; background: var(--bg-inset); border-radius: 2px; overflow: hidden; }
-.cx-status-mem-bar > div { height: 100%; background: var(--fg-subtle); }
-
 /* Command Palette */
 .cx-palette-backdrop {
   position: fixed; inset: 0; background: rgba(0,0,0,0.5);

--- a/app/src/lib/export.test.ts
+++ b/app/src/lib/export.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { concordanceCsv, concordanceJson, documentsCsv, slug } from "./export";
+import type { KwicResult } from "@/types";
+
+const result: KwicResult = {
+  hits: [
+    { docId: "a.txt", pos: 10, left: "to be, or not", hit: "to", right: 'be — "that" is', lemma: "be", pos_tag: "VB" },
+    { docId: "b.txt", pos: 22, left: "plain left", hit: "to", right: "plain right" },
+  ],
+  elapsedMs: 1.2,
+  truncated: false,
+  total: 2,
+  offset: 0,
+};
+
+describe("concordanceCsv", () => {
+  it("emits a header and one row per hit", () => {
+    const lines = concordanceCsv(result).trimEnd().split("\r\n");
+    expect(lines[0]).toBe("n,doc,position,left,node,right");
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toBe("2,b.txt,22,plain left,to,plain right");
+  });
+
+  it("quotes fields containing commas, quotes, or newlines and doubles inner quotes", () => {
+    const row = concordanceCsv(result).split("\r\n")[1];
+    // left "to be, or not" → quoted (comma); right with embedded quotes → doubled
+    expect(row).toContain('"to be, or not"');
+    expect(row).toContain('"be — ""that"" is"');
+  });
+});
+
+describe("concordanceJson", () => {
+  it("carries query context and per-hit fields, omitting absent lemma/pos", () => {
+    const parsed = JSON.parse(concordanceJson(result, null, "to", "word"));
+    expect(parsed).toMatchObject({ corpus: null, term: "to", layer: "word", total: 2 });
+    expect(parsed.hits[0]).toMatchObject({ doc: "a.txt", node: "to", lemma: "be", posTag: "VB" });
+    expect(parsed.hits[1]).not.toHaveProperty("lemma");
+    expect(parsed.hits[1]).not.toHaveProperty("posTag");
+  });
+});
+
+describe("documentsCsv", () => {
+  it("renders null title/author/year as empty cells", () => {
+    const csv = documentsCsv([{ file: "a.txt", title: null, author: null, year: null, tokens: 99 }]);
+    const lines = csv.trimEnd().split("\r\n");
+    expect(lines[0]).toBe("file,title,author,year,tokens");
+    expect(lines[1]).toBe("a.txt,,,,99");
+  });
+});
+
+describe("slug", () => {
+  it("lowercases, collapses non-alphanumerics, and trims dashes", () => {
+    expect(slug("Gutenberg · EN")).toBe("gutenberg-en");
+    expect(slug("  NYT 2020–2025  ")).toBe("nyt-2020-2025");
+  });
+
+  it("falls back to 'corpus' for empty input", () => {
+    expect(slug("···")).toBe("corpus");
+  });
+});

--- a/app/src/lib/export.ts
+++ b/app/src/lib/export.ts
@@ -1,0 +1,97 @@
+// File export for the concordance and the corpus document list. The rows
+// are already in memory, so the text is built client-side and written
+// out — via the native save dialog inside Tauri, or a browser download in
+// the vite-only preview.
+
+import type { CorpusMeta, KwicResult, QueryLayer } from "@/types";
+import { inTauri, writeTextFile } from "@/lib/tauri";
+
+/** RFC-4180-ish field escaping: quote when the value carries a comma,
+ *  quote, CR or LF, doubling any embedded quotes. */
+function csvField(value: string | number): string {
+  const s = String(value);
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function toCsv(headers: string[], rows: (string | number)[][]): string {
+  return [headers, ...rows].map((r) => r.map(csvField).join(",")).join("\r\n") + "\r\n";
+}
+
+/** A filesystem-safe slug for default export filenames. */
+export function slug(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "corpus";
+}
+
+export function concordanceCsv(result: KwicResult): string {
+  return toCsv(
+    ["n", "doc", "position", "left", "node", "right"],
+    result.hits.map((h, i) => [i + 1, h.docId, h.pos, h.left, h.hit, h.right]),
+  );
+}
+
+export function concordanceJson(
+  result: KwicResult,
+  corpus: CorpusMeta | null,
+  term: string,
+  layer: QueryLayer,
+): string {
+  return JSON.stringify(
+    {
+      corpus: corpus?.name ?? null,
+      term,
+      layer,
+      total: result.total,
+      hits: result.hits.map((h) => ({
+        doc: h.docId,
+        position: h.pos,
+        left: h.left,
+        node: h.hit,
+        right: h.right,
+        ...(h.lemma ? { lemma: h.lemma } : {}),
+        ...(h.pos_tag ? { posTag: h.pos_tag } : {}),
+      })),
+    },
+    null,
+    2,
+  );
+}
+
+export interface DocExportRow {
+  file: string;
+  title: string | null;
+  author: string | null;
+  year: number | null;
+  tokens: number;
+}
+
+export function documentsCsv(rows: DocExportRow[]): string {
+  return toCsv(
+    ["file", "title", "author", "year", "tokens"],
+    rows.map((d) => [d.file, d.title ?? "", d.author ?? "", d.year ?? "", d.tokens]),
+  );
+}
+
+/** Write text to a user-chosen path (Tauri save dialog) or trigger a
+ *  browser download (vite preview). No-ops if the user cancels. */
+export async function saveText(suggestedName: string, contents: string, mime: string): Promise<void> {
+  if (inTauri()) {
+    const { save } = await import("@tauri-apps/plugin-dialog");
+    const ext = suggestedName.includes(".") ? suggestedName.split(".").pop()! : "";
+    const path = await save({
+      defaultPath: suggestedName,
+      filters: ext ? [{ name: ext.toUpperCase(), extensions: [ext] }] : undefined,
+    });
+    if (!path) return;
+    await writeTextFile(path, contents);
+    return;
+  }
+  const blob = new Blob([contents], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = suggestedName;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1,7 +1,6 @@
-// Thin typed wrapper over Tauri's `invoke`. Today these are stubs — real
-// implementations land once the commands in app/src-tauri/src/commands.rs
-// are fleshed out. UI code reaches through these fns so swapping fixture
-// data for real IPC is a single-file change.
+// Thin typed wrapper over Tauri's `invoke`. Each fn calls a real command
+// implemented in app/src-tauri/src/commands.rs. UI code reaches through
+// these so the fixture-vs-IPC decision (see hasLiveData) stays in one place.
 
 import { CORPORA } from "@/data";
 import type {
@@ -188,6 +187,12 @@ export async function runTermDistribution(req: TermDistRequest): Promise<TermDis
 
 export async function expandContext(req: ExpandRequest): Promise<ExpandedContext> {
   return invokeSafe<ExpandedContext>("expand_context", { req });
+}
+
+/** Write a UTF-8 string to an absolute path on disk. Backs the export
+ *  actions once the save dialog has chosen a destination. */
+export async function writeTextFile(path: string, contents: string): Promise<void> {
+  return invokeSafe<void>("write_text_file", { path, contents });
 }
 
 /** True when running inside the Tauri shell. Frontend can fall back to


### PR DESCRIPTION
Follow-up to the demo-stuff audit. The backend commands are all real, but several UI controls were still inert placeholders. This wires them to real behaviour and removes the ones that can't be honest yet.

## Made real
- **Export** (was dead in 3 places: concordance "export csv" button, the ⌘E + JSON command-palette entries, and corpus-detail "export"):
  - new minimal `write_text_file` Tauri command + `dialog:allow-save` / `opener:allow-reveal-item-in-dir` capabilities;
  - `lib/export.ts` builds concordance CSV/JSON and the doc-list CSV, saving via the native save dialog in Tauri or a browser download in the vite preview;
  - the ⌘E shortcut now actually fires (it was only a label before).
- **Corpus-detail "reveal"** opens the index folder via the opener plugin (disabled for fixtures, which have no real path).
- **Hit-density gutter** thumb tracks the real concordance scroll position, and clicking it scrolls there (was `scrollPct = 0.18` + a no-op `onJump`).

## Removed (can't be honest now → issue/nuke)
- the fake status-bar memory meter — filed #47 for a real index/memory footprint indicator;
- the dummy `year: 1800–1950` filter chip + dead `+ filter` button — the real metadata-filter feature stays tracked in #30 (commented).

## Also
- corrected stale "stubs / will be replaced by IPC" comments in `App.tsx`, `data.ts`, `lib/tauri.ts`, `src-tauri/lib.rs`.

## Verification
- `cargo check` (backend compiles), `tsc -b` + `vite build`, and **61 vitest tests pass** (added `export.test.ts` for the CSV/JSON serializers + escaping).
- Visually confirmed in the browser: filter chip and memory meter gone, export button present, concordance layout intact.
- Note: the native save/write/reveal paths are verified by compilation + capability config, not by running the packaged Tauri app; the browser-download export path was exercised in preview.

ref #30, ref #47