### PR TITLE
Document-metadata query filter across all query surfaces

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -179,7 +179,14 @@ fn run_collocates_inner(
     let (collocates, node_freq, window_tokens, truncated) =
         with_corpus(state, &req.corpus_id, |index| {
             let scan = index
-                .collocate_counts_filtered(&req.term, layer, lw, rw, MAX_NODE_OCCURRENCES, Some(&filter))
+                .collocate_counts_filtered(
+                    &req.term,
+                    layer,
+                    lw,
+                    rw,
+                    MAX_NODE_OCCURRENCES,
+                    Some(&filter),
+                )
                 .map_err(|e| format!("collocate scan failed: {e:#}"))?;
 
             // Corpus size and collocate marginals are taken on the
@@ -492,7 +499,14 @@ fn run_collocate_distance_inner(
 
     let (offsets, mut rows, node_freq, truncated) = with_corpus(state, &req.corpus_id, |index| {
         let prof = index
-            .collocate_by_distance_filtered(&req.term, layer, lw, rw, MAX_NODE_OCCURRENCES, Some(&filter))
+            .collocate_by_distance_filtered(
+                &req.term,
+                layer,
+                lw,
+                rw,
+                MAX_NODE_OCCURRENCES,
+                Some(&filter),
+            )
             .map_err(|e| format!("distance scan failed: {e:#}"))?;
         let node_word = req.term.trim().to_lowercase();
         let rows: Vec<DistanceRow> = prof

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -8,9 +8,10 @@
 use crate::{
     AppState, BuildRequest, Collocate as CollocateDto, CollocateDistanceRequest,
     CollocateDistanceResult, CollocatesRequest, CollocatesResult, CorpusMeta, CorpusMetaEnvelope,
-    DistanceRow, DocTermCount as DocTermCountDto, DocumentInfo as DocumentInfoDto, ExpandRequest,
-    ExpandedContext, FreqRow, FrequenciesRequest, FrequenciesResult, KwicHit as KwicHitDto,
-    KwicRequest, KwicResult, OpenedCorpus, TaggerKind, TermDistRequest, TermDistResult,
+    DistanceRow, DocFilterDto, DocTermCount as DocTermCountDto, DocumentInfo as DocumentInfoDto,
+    ExpandRequest, ExpandedContext, FreqRow, FrequenciesRequest, FrequenciesResult,
+    KwicHit as KwicHitDto, KwicRequest, KwicResult, OpenedCorpus, TaggerKind, TermDistRequest,
+    TermDistResult,
 };
 use corpust_annotate::{Annotator, treetagger::TreeTagger};
 use corpust_index::{CorpusIndex, DEFAULT_CONTEXT, QueryLayer};
@@ -172,19 +173,20 @@ fn run_collocates_inner(
     let layer: QueryLayer = req.layer.into();
     let limit = req.limit.clamp(1, 200);
     let span = (lw + rw) as u64;
+    let filter = DocFilterDto::resolve(req.filter.clone());
     let t0 = Instant::now();
 
     let (collocates, node_freq, window_tokens, truncated) =
         with_corpus(state, &req.corpus_id, |index| {
             let scan = index
-                .collocate_counts(&req.term, layer, lw, rw, MAX_NODE_OCCURRENCES)
+                .collocate_counts_filtered(&req.term, layer, lw, rw, MAX_NODE_OCCURRENCES, Some(&filter))
                 .map_err(|e| format!("collocate scan failed: {e:#}"))?;
 
             // Corpus size and collocate marginals are taken on the
             // surface (word) layer — collocates are surface forms read
             // from `body`, regardless of which layer the node matched on.
             let n = index
-                .layer_total_tokens(corpust_index::QueryLayer::Word)
+                .layer_total_tokens_filtered(corpust_index::QueryLayer::Word, Some(&filter))
                 .map_err(|e| format!("corpus size lookup failed: {e:#}"))?;
 
             // Bound the marginal lookups: score a generous top-by-raw-count
@@ -205,7 +207,7 @@ fn run_collocates_inner(
 
             let words: Vec<String> = cand.iter().map(|(w, _, _)| w.clone()).collect();
             let f_coll = index
-                .term_totals(&words, corpust_index::QueryLayer::Word)
+                .term_totals_filtered(&words, corpust_index::QueryLayer::Word, Some(&filter))
                 .map_err(|e| format!("collocate frequency lookup failed: {e:#}"))?;
 
             let mut collocates: Vec<CollocateDto> = cand
@@ -278,7 +280,8 @@ fn run_kwic_inner(state: &State<'_, AppState>, req: &KwicRequest) -> Result<Kwic
         .layer(req.layer.into())
         .context(context)
         .limit(limit)
-        .offset(req.offset);
+        .offset(req.offset)
+        .filter(DocFilterDto::resolve(req.filter.clone()));
 
     let t0 = Instant::now();
     let page = with_corpus(state, &req.corpus_id, |index| {
@@ -372,17 +375,27 @@ fn run_frequencies_inner(
 ) -> Result<FrequenciesResult, String> {
     let limit = req.limit.clamp(1, 1000);
     let layer: QueryLayer = req.layer.into();
+    let filter = DocFilterDto::resolve(req.filter.clone());
     let t0 = Instant::now();
-    // Prefer the precomputed sidecar written at build time; fall back to
-    // a live term-dictionary scan for corpora built before it existed
-    // (or if the request asks for more rows than were precomputed).
-    let (rows, total_tokens) = match load_precomputed_frequencies(&req.corpus_id, layer, limit) {
-        Some(table) => table,
-        None => with_corpus(state, &req.corpus_id, |index| {
+    // With no filter, prefer the precomputed sidecar written at build time
+    // (falling back to a live term-dictionary scan for older corpora or
+    // deeper requests). A filter scopes the counts to a subcorpus, so the
+    // corpus-wide sidecar can't apply — scan live, restricted to matches.
+    let (rows, total_tokens) = if filter.is_empty() {
+        match load_precomputed_frequencies(&req.corpus_id, layer, limit) {
+            Some(table) => table,
+            None => with_corpus(state, &req.corpus_id, |index| {
+                index
+                    .frequencies(layer, limit)
+                    .map_err(|e| format!("frequencies failed: {e:#}"))
+            })?,
+        }
+    } else {
+        with_corpus(state, &req.corpus_id, |index| {
             index
-                .frequencies(layer, limit)
+                .frequencies_filtered(layer, limit, Some(&filter))
                 .map_err(|e| format!("frequencies failed: {e:#}"))
-        })?,
+        })?
     };
     let denom = total_tokens.max(1) as f64;
     let rows = rows
@@ -423,10 +436,11 @@ fn run_term_distribution_inner(
     req: &TermDistRequest,
 ) -> Result<TermDistResult, String> {
     let buckets = req.buckets.clamp(1, 1000);
+    let filter = DocFilterDto::resolve(req.filter.clone());
     let t0 = Instant::now();
     let dist = with_corpus(state, &req.corpus_id, |index| {
         index
-            .term_distribution(&req.term, req.layer.into(), buckets)
+            .term_distribution_filtered(&req.term, req.layer.into(), buckets, Some(&filter))
             .map_err(|e| format!("term distribution failed: {e:#}"))
     })?;
     Ok(TermDistResult {
@@ -473,11 +487,12 @@ fn run_collocate_distance_inner(
     }
     let layer: QueryLayer = req.layer.into();
     let limit = req.limit.clamp(1, 60);
+    let filter = DocFilterDto::resolve(req.filter.clone());
     let t0 = Instant::now();
 
     let (offsets, mut rows, node_freq, truncated) = with_corpus(state, &req.corpus_id, |index| {
         let prof = index
-            .collocate_by_distance(&req.term, layer, lw, rw, MAX_NODE_OCCURRENCES)
+            .collocate_by_distance_filtered(&req.term, layer, lw, rw, MAX_NODE_OCCURRENCES, Some(&filter))
             .map_err(|e| format!("distance scan failed: {e:#}"))?;
         let node_word = req.term.trim().to_lowercase();
         let rows: Vec<DistanceRow> = prof

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -86,6 +86,40 @@ impl From<QueryLayer> for corpust_index::QueryLayer {
     }
 }
 
+/// Document-metadata filter shared by every query command. Empty
+/// dimensions (the default) impose no constraint. Mirrors the TS
+/// `DocFilter` and converts into [`corpust_index::DocFilter`].
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocFilterDto {
+    #[serde(default)]
+    pub year_min: Option<u32>,
+    #[serde(default)]
+    pub year_max: Option<u32>,
+    #[serde(default)]
+    pub author: Option<String>,
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+impl From<DocFilterDto> for corpust_index::DocFilter {
+    fn from(f: DocFilterDto) -> Self {
+        corpust_index::DocFilter {
+            year_min: f.year_min,
+            year_max: f.year_max,
+            author: f.author,
+            path: f.path,
+        }
+    }
+}
+
+impl DocFilterDto {
+    /// Convert an optional DTO into a resolved filter (empty when absent).
+    pub fn resolve(opt: Option<DocFilterDto>) -> corpust_index::DocFilter {
+        opt.map(Into::into).unwrap_or_default()
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KwicRequest {
@@ -97,6 +131,8 @@ pub struct KwicRequest {
     /// Hits to skip before this page (concordance pagination).
     #[serde(default)]
     pub offset: usize,
+    #[serde(default)]
+    pub filter: Option<DocFilterDto>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -137,6 +173,8 @@ pub struct CollocatesRequest {
     pub right_window: usize,
     /// Max number of collocate candidates to return.
     pub limit: usize,
+    #[serde(default)]
+    pub filter: Option<DocFilterDto>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -224,6 +262,8 @@ pub struct FrequenciesRequest {
     pub corpus_id: String,
     pub layer: QueryLayer,
     pub limit: usize,
+    #[serde(default)]
+    pub filter: Option<DocFilterDto>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -251,6 +291,8 @@ pub struct TermDistRequest {
     pub term: String,
     pub layer: QueryLayer,
     pub buckets: usize,
+    #[serde(default)]
+    pub filter: Option<DocFilterDto>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -283,6 +325,8 @@ pub struct CollocateDistanceRequest {
     pub right_window: usize,
     /// How many of the busiest collocates to return rows for.
     pub limit: usize,
+    #[serde(default)]
+    pub filter: Option<DocFilterDto>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -24,11 +24,13 @@ import { CommandPalette, type CommandDef } from "@/components/overlays/CommandPa
 import { BuildDialog } from "@/components/overlays/BuildDialog";
 import { CORPORA, RECENT_QUERIES, pickHits } from "@/data";
 import { concordanceCsv, concordanceJson, saveText, slug } from "@/lib/export";
+import { normalizeFilter } from "@/lib/filter";
 import { makeDensity } from "@/lib/utils";
-import { inTauri, isFixtureCorpus, listCorpora, runCollocates, runKwic as runKwicTauri } from "@/lib/tauri";
+import { hasLiveData, inTauri, isFixtureCorpus, listCorpora, runCollocates, runKwic as runKwicTauri } from "@/lib/tauri";
 import type { Collocate } from "@/types";
 import type {
   CorpusMeta,
+  DocFilter,
   KwicHit,
   KwicResult,
   MainView,
@@ -71,6 +73,11 @@ export function App() {
   );
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [buildOpen, setBuildOpen] = useState(false);
+  // Document-metadata filter applied to every query. `queryFilter` is the
+  // normalized form (empty dimensions dropped, or undefined when nothing
+  // is set) that travels to the backend.
+  const [filter, setFilter] = useState<DocFilter>({});
+  const queryFilter = useMemo(() => normalizeFilter(filter), [filter]);
   // Concordance scroll position (0–1), tracked from the KWIC column so the
   // hit-density gutter's thumb reflects where you actually are, and clicks
   // on the gutter scroll there.
@@ -143,7 +150,7 @@ export function App() {
         }
         return;
       }
-      runKwicTauri({ corpusId: corpus.id, term: q.trim(), layer: lyr, context: 8, limit: KWIC_PAGE, offset })
+      runKwicTauri({ corpusId: corpus.id, term: q.trim(), layer: lyr, context: 8, limit: KWIC_PAGE, offset, filter: queryFilter })
         .then((r) => {
           if (myId !== kwicReqRef.current) return;
           const hits: KwicHit[] = r.hits.map((h, i) => ({
@@ -167,7 +174,7 @@ export function App() {
           if (myId === kwicReqRef.current) setLoading(false);
         });
     },
-    [],
+    [queryFilter],
   );
 
   // Auto-fetch on corpus / term / layer change — always resets to the
@@ -257,6 +264,7 @@ export function App() {
       leftWindow: collLeft,
       rightWindow: collRight,
       limit: 60,
+      filter: queryFilter,
     })
       .then((r) => {
         if (myId !== collReqRef.current) return;
@@ -276,7 +284,7 @@ export function App() {
   useEffect(() => {
     fetchCollocates();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [subview, activeCorpus, layer, collLeft, collRight]);
+  }, [subview, activeCorpus, layer, collLeft, collRight, queryFilter]);
 
   useEffect(() => {
     const t = window.setTimeout(fetchCollocates, 100);
@@ -421,6 +429,9 @@ export function App() {
           disabled={!activeCorpus}
           annotated={!!activeCorpus?.annotated}
           onOpenPalette={() => setPaletteOpen(true)}
+          filter={filter}
+          onFilterChange={setFilter}
+          filterable={!!activeCorpus && hasLiveData(activeCorpus.id)}
         />
         <ViewTabs view={subview} onView={setSubview} result={result} />
         <div className="cx-results-wrap">
@@ -469,16 +480,16 @@ export function App() {
             />
           )}
           {subview === "freq" && activeCorpus && (
-            <FrequencyView corpus={activeCorpus} term={term} />
+            <FrequencyView corpus={activeCorpus} term={term} filter={queryFilter} />
           )}
           {subview === "tree" && activeCorpus && (
             <WordTree corpusName={activeCorpus.name} term={term} result={result} loading={loading} />
           )}
           {subview === "dist" && activeCorpus && (
-            <CollocationDistance corpus={activeCorpus} term={term} layer={layer} />
+            <CollocationDistance corpus={activeCorpus} term={term} layer={layer} filter={queryFilter} />
           )}
           {subview === "time" && activeCorpus && (
-            <FrequencyOverTime corpus={activeCorpus} term={term} layer={layer} />
+            <FrequencyOverTime corpus={activeCorpus} term={term} layer={layer} filter={queryFilter} />
           )}
         </div>
       </>

--- a/app/src/components/analyses/CollocationDistance.tsx
+++ b/app/src/components/analyses/CollocationDistance.tsx
@@ -10,18 +10,20 @@ import {
   hasLiveData,
   runCollocateDistance,
 } from "@/lib/tauri";
-import type { CorpusMeta, QueryLayer } from "@/types";
+import type { CorpusMeta, DocFilter, QueryLayer } from "@/types";
 
 export interface CollocationDistanceProps {
   corpus: CorpusMeta;
   term: string;
   layer: QueryLayer;
+  /** Active metadata filter (already normalized); scopes the scan. */
+  filter?: DocFilter;
 }
 
 const WINDOW = 5;
 const LIMIT = 25;
 
-export function CollocationDistance({ corpus, term, layer }: CollocationDistanceProps) {
+export function CollocationDistance({ corpus, term, layer, filter }: CollocationDistanceProps) {
   const isLive = hasLiveData(corpus.id);
   const [offsets, setOffsets] = useState<number[] | null>(null);
   const [rows, setRows] = useState<DistanceRow[] | null>(null);
@@ -40,6 +42,7 @@ export function CollocationDistance({ corpus, term, layer }: CollocationDistance
       leftWindow: WINDOW,
       rightWindow: WINDOW,
       limit: LIMIT,
+      filter,
     })
       .then((r) => {
         if (cancelled) return;
@@ -59,7 +62,7 @@ export function CollocationDistance({ corpus, term, layer }: CollocationDistance
     return () => {
       cancelled = true;
     };
-  }, [corpus.id, term, layer, isLive]);
+  }, [corpus.id, term, layer, isLive, filter]);
 
   const maxCount = useMemo(
     () => Math.max(1, ...(rows ?? []).flatMap((r) => r.counts)),

--- a/app/src/components/analyses/FrequencyOverTime.tsx
+++ b/app/src/components/analyses/FrequencyOverTime.tsx
@@ -7,13 +7,17 @@
 // being bigger.
 
 import { useEffect, useMemo, useState } from "react";
+import { docMatchesFilter } from "@/lib/filter";
 import { hasLiveData, listDocuments, runTermDistribution } from "@/lib/tauri";
-import type { CorpusMeta, QueryLayer } from "@/types";
+import type { CorpusMeta, DocFilter, QueryLayer } from "@/types";
 
 export interface FrequencyOverTimeProps {
   corpus: CorpusMeta;
   term: string;
   layer: QueryLayer;
+  /** Active metadata filter (already normalized). Scopes the hit counts
+   *  and the per-year token denominator to the same subcorpus. */
+  filter?: DocFilter;
 }
 
 interface YearPoint {
@@ -49,7 +53,7 @@ function yearTicks(min: number, max: number, count = 6): number[] {
   return out;
 }
 
-export function FrequencyOverTime({ corpus, term, layer }: FrequencyOverTimeProps) {
+export function FrequencyOverTime({ corpus, term, layer, filter }: FrequencyOverTimeProps) {
   const isLive = hasLiveData(corpus.id);
   const [points, setPoints] = useState<YearPoint[] | null>(null);
   const [undated, setUndated] = useState(0);
@@ -64,10 +68,13 @@ export function FrequencyOverTime({ corpus, term, layer }: FrequencyOverTimeProp
     setLoading(true);
     Promise.all([
       listDocuments(corpus.id),
-      runTermDistribution({ corpusId: corpus.id, term: term.trim(), layer, buckets: 100 }),
+      runTermDistribution({ corpusId: corpus.id, term: term.trim(), layer, buckets: 100, filter }),
     ])
-      .then(([docs, dist]) => {
+      .then(([allDocs, dist]) => {
         if (cancelled) return;
+        // Restrict the per-year token denominator to the same subcorpus
+        // the filter scoped the hits to, so per-1M stays accurate.
+        const docs = allDocs.filter((d) => docMatchesFilter(d, filter));
         const hitsByDoc = new Map<number, number>();
         for (const d of dist.docCounts) hitsByDoc.set(d.docId, d.hits);
 
@@ -101,7 +108,7 @@ export function FrequencyOverTime({ corpus, term, layer }: FrequencyOverTimeProp
     return () => {
       cancelled = true;
     };
-  }, [corpus.id, term, layer, isLive]);
+  }, [corpus.id, term, layer, isLive, filter]);
 
   const scale = useMemo(() => {
     const pts = points ?? [];

--- a/app/src/components/analyses/FrequencyView.tsx
+++ b/app/src/components/analyses/FrequencyView.tsx
@@ -8,11 +8,13 @@ import {
   runTermDistribution,
 } from "@/lib/tauri";
 import { basename } from "@/lib/utils";
-import type { CorpusMeta, FreqBy } from "@/types";
+import type { CorpusMeta, DocFilter, FreqBy } from "@/types";
 
 export interface FrequencyViewProps {
   corpus: CorpusMeta;
   term: string;
+  /** Active metadata filter (already normalized); scopes both tables. */
+  filter?: DocFilter;
 }
 
 /** How many bars to show in the top-terms list, and how many buckets to
@@ -49,7 +51,7 @@ interface DocFreqRow {
   per1m: number;
 }
 
-export function FrequencyView({ corpus, term }: FrequencyViewProps) {
+export function FrequencyView({ corpus, term, filter }: FrequencyViewProps) {
   const [by, setBy] = useState<FreqBy>("word");
   const [liveFreq, setLiveFreq] = useState<FreqResultRow[] | null>(null);
   const [liveDist, setLiveDist] = useState<TermDistResult | null>(null);
@@ -63,7 +65,7 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
     setLiveFreq(null);
     if (!hasLiveData(corpus.id)) return;
     let cancelled = false;
-    runFrequencies({ corpusId: corpus.id, layer: by, limit: TOP_N })
+    runFrequencies({ corpusId: corpus.id, layer: by, limit: TOP_N, filter })
       .then((r) => {
         if (!cancelled) setLiveFreq(r.rows);
       })
@@ -74,14 +76,14 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
     return () => {
       cancelled = true;
     };
-  }, [corpus.id, by]);
+  }, [corpus.id, by, filter]);
 
   // Per-document hit counts + dispersion for the queried term.
   useEffect(() => {
     setLiveDist(null);
     if (!hasLiveData(corpus.id) || !term.trim()) return;
     let cancelled = false;
-    runTermDistribution({ corpusId: corpus.id, term: term.trim(), layer: by, buckets: BUCKETS })
+    runTermDistribution({ corpusId: corpus.id, term: term.trim(), layer: by, buckets: BUCKETS, filter })
       .then((r) => {
         if (!cancelled) setLiveDist(r);
       })
@@ -92,7 +94,7 @@ export function FrequencyView({ corpus, term }: FrequencyViewProps) {
     return () => {
       cancelled = true;
     };
-  }, [corpus.id, term, by]);
+  }, [corpus.id, term, by, filter]);
 
   const isLive = hasLiveData(corpus.id);
   // For a live corpus, show the spinner until the *real* data arrives —

--- a/app/src/components/query/QueryBar.test.tsx
+++ b/app/src/components/query/QueryBar.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryBar, type QueryBarProps } from "./QueryBar";
+
+function setup(overrides: Partial<QueryBarProps> = {}) {
+  const onFilterChange = vi.fn();
+  const props: QueryBarProps = {
+    layer: "word",
+    term: "linguistic",
+    onLayer: vi.fn(),
+    onTerm: vi.fn(),
+    onRun: vi.fn(),
+    onOpenPalette: vi.fn(),
+    filter: {},
+    onFilterChange,
+    filterable: true,
+    ...overrides,
+  };
+  render(<QueryBar {...props} />);
+  return { onFilterChange };
+}
+
+describe("QueryBar filter", () => {
+  it("hides the filter control entirely when the corpus isn't filterable", () => {
+    setup({ filterable: false, filter: { author: "x" } });
+    expect(screen.queryByRole("button", { name: /filter/i })).toBeNull();
+    // Not even an existing filter's chip leaks through on a fixture corpus.
+    expect(screen.queryByText(/author: x/i)).toBeNull();
+  });
+
+  it("renders a removable chip per active dimension", () => {
+    const { onFilterChange } = setup({ filter: { yearMin: 1800, yearMax: 1950 } });
+    const chip = screen.getByText(/year: 1800–1950/i);
+    expect(chip).toBeInTheDocument();
+    fireEvent.click(chip);
+    expect(onFilterChange).toHaveBeenCalledWith({}); // year cleared
+  });
+
+  it("opens the popover and commits a normalized filter on Apply", () => {
+    const { onFilterChange } = setup();
+    fireEvent.click(screen.getByRole("button", { name: /filter/i }));
+    fireEvent.change(screen.getByPlaceholderText("from"), { target: { value: "1850" } });
+    fireEvent.change(screen.getByPlaceholderText("to"), { target: { value: "1900" } });
+    fireEvent.change(screen.getByLabelText("author"), { target: { value: "  Austen  " } });
+    fireEvent.click(screen.getByRole("button", { name: /apply/i }));
+    expect(onFilterChange).toHaveBeenCalledWith({ yearMin: 1850, yearMax: 1900, author: "Austen" });
+  });
+});

--- a/app/src/components/query/QueryBar.tsx
+++ b/app/src/components/query/QueryBar.tsx
@@ -1,6 +1,7 @@
-import { Search } from "lucide-react";
-import type { FormEvent } from "react";
-import type { QueryLayer } from "@/types";
+import { Plus, Search, X } from "lucide-react";
+import { type FormEvent, useEffect, useState } from "react";
+import { clearDimension, filterChips, normalizeFilter } from "@/lib/filter";
+import type { DocFilter, QueryLayer } from "@/types";
 
 const LAYERS: { value: QueryLayer; label: string; hint: string }[] = [
   { value: "word", label: "word", hint: "surface form · case-insensitive" },
@@ -17,6 +18,12 @@ export interface QueryBarProps {
   disabled?: boolean;
   annotated?: boolean;
   onOpenPalette: () => void;
+  /** Active document-metadata filter (raw, un-normalized). */
+  filter: DocFilter;
+  onFilterChange: (f: DocFilter) => void;
+  /** Whether the active corpus supports filtering (real, backend-backed).
+   *  Fixtures / preview have no queryable metadata, so the control hides. */
+  filterable: boolean;
 }
 
 export function QueryBar({
@@ -28,11 +35,16 @@ export function QueryBar({
   disabled,
   annotated,
   onOpenPalette,
+  filter,
+  onFilterChange,
+  filterable,
 }: QueryBarProps) {
   const submit = (e: FormEvent) => {
     e.preventDefault();
     if (term.trim()) onRun();
   };
+
+  const chips = filterChips(filter);
 
   return (
     <form onSubmit={submit} className="cx-querybar">
@@ -75,6 +87,27 @@ export function QueryBar({
         <div className="cx-input-suffix">{term && <span>{layer === "pos" ? "exact" : "regex ok"}</span>}</div>
       </div>
 
+      {filterable && (
+        <>
+          {chips.map((c) => (
+            <span
+              key={c.key}
+              className="cx-filter-chip is-on"
+              onClick={() => onFilterChange(clearDimension(filter, c.key))}
+              title="Remove filter"
+              role="button"
+              tabIndex={0}
+            >
+              {c.label}
+              <span className="x">
+                <X size={10} />
+              </span>
+            </span>
+          ))}
+          <FilterEditor filter={filter} onChange={onFilterChange} />
+        </>
+      )}
+
       <button type="submit" className="cx-btn cx-btn-primary" disabled={disabled || !term.trim()}>
         Run
       </button>
@@ -87,5 +120,124 @@ export function QueryBar({
         <span style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--fg-muted)" }}>⌘K</span>
       </button>
     </form>
+  );
+}
+
+/** A small popover to add/edit metadata filters. Edits a local draft and
+ *  commits on Apply, so each keystroke doesn't refetch every query. */
+function FilterEditor({ filter, onChange }: { filter: DocFilter; onChange: (f: DocFilter) => void }) {
+  const [open, setOpen] = useState(false);
+  const [yearMin, setYearMin] = useState("");
+  const [yearMax, setYearMax] = useState("");
+  const [author, setAuthor] = useState("");
+  const [path, setPath] = useState("");
+
+  // Seed the draft from the active filter whenever the popover opens.
+  useEffect(() => {
+    if (!open) return;
+    setYearMin(filter.yearMin != null ? String(filter.yearMin) : "");
+    setYearMax(filter.yearMax != null ? String(filter.yearMax) : "");
+    setAuthor(filter.author ?? "");
+    setPath(filter.path ?? "");
+  }, [open, filter]);
+
+  // Close on Escape while open.
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [open]);
+
+  const apply = () => {
+    const draft: DocFilter = {
+      yearMin: yearMin.trim() ? Number(yearMin) : undefined,
+      yearMax: yearMax.trim() ? Number(yearMax) : undefined,
+      author: author.trim() || undefined,
+      path: path.trim() || undefined,
+    };
+    onChange(normalizeFilter(draft) ?? {});
+    setOpen(false);
+  };
+
+  return (
+    <span className="cx-filter-wrap">
+      <button
+        type="button"
+        className="cx-filter-chip"
+        title="Filter by document metadata"
+        onClick={() => setOpen((o) => !o)}
+      >
+        <Plus size={10} />
+        filter
+      </button>
+      {open && (
+        <>
+          <div className="cx-filter-backdrop" onClick={() => setOpen(false)} />
+          <div className="cx-filter-pop" onClick={(e) => e.stopPropagation()}>
+            <div className="cx-filter-pop-title">Filter documents</div>
+            <label className="cx-filter-row">
+              <span>year</span>
+              <span className="cx-filter-range">
+                <input
+                  type="number"
+                  className="cx-filter-input"
+                  placeholder="from"
+                  value={yearMin}
+                  onChange={(e) => setYearMin(e.target.value)}
+                />
+                <span className="cx-filter-dash">–</span>
+                <input
+                  type="number"
+                  className="cx-filter-input"
+                  placeholder="to"
+                  value={yearMax}
+                  onChange={(e) => setYearMax(e.target.value)}
+                />
+              </span>
+            </label>
+            <label className="cx-filter-row">
+              <span>author</span>
+              <input
+                type="text"
+                className="cx-filter-input wide"
+                placeholder="contains…"
+                value={author}
+                onChange={(e) => setAuthor(e.target.value)}
+                spellCheck={false}
+              />
+            </label>
+            <label className="cx-filter-row">
+              <span>path</span>
+              <input
+                type="text"
+                className="cx-filter-input wide"
+                placeholder="contains…"
+                value={path}
+                onChange={(e) => setPath(e.target.value)}
+                spellCheck={false}
+              />
+            </label>
+            <div className="cx-filter-actions">
+              <button
+                type="button"
+                className="cx-btn cx-btn-outline"
+                onClick={() => {
+                  onChange({});
+                  setOpen(false);
+                }}
+              >
+                Clear
+              </button>
+              <button type="button" className="cx-btn cx-btn-primary" onClick={apply}>
+                Apply
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </span>
   );
 }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -368,6 +368,39 @@
 .cx-filter-chip .x { color: var(--fg-subtle); display: inline-flex; }
 .cx-filter-chip .x:hover { color: var(--danger); }
 
+/* Metadata-filter popover (opened from the + filter chip) */
+.cx-filter-wrap { position: relative; display: inline-flex; }
+.cx-filter-backdrop { position: fixed; inset: 0; z-index: 19; }
+.cx-filter-pop {
+  position: absolute; top: calc(100% + 6px); right: 0; z-index: 20;
+  width: 260px; padding: 12px;
+  background: var(--bg-raised); border: 1px solid var(--border-strong);
+  border-radius: 8px; box-shadow: var(--shadow-lg);
+  display: flex; flex-direction: column; gap: 10px;
+  animation: cx-slide-in var(--dur-2) var(--ease);
+}
+.cx-filter-pop-title {
+  font-family: var(--font-mono); font-size: 10px; color: var(--fg-subtle);
+  text-transform: uppercase; letter-spacing: 0.05em;
+}
+.cx-filter-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.cx-filter-row > span:first-child {
+  font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted); width: 48px;
+}
+.cx-filter-range { display: inline-flex; align-items: center; gap: 6px; }
+.cx-filter-dash { color: var(--fg-subtle); }
+.cx-filter-input {
+  height: 28px; width: 64px; padding: 0 8px;
+  background: var(--bg-inset); border: 1px solid var(--border); border-radius: 4px;
+  color: var(--fg); font-family: var(--font-mono); font-size: 12px; outline: none;
+  transition: border-color var(--dur-1) var(--ease), box-shadow var(--dur-1) var(--ease);
+}
+.cx-filter-input.wide { width: 150px; }
+.cx-filter-input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px color-mix(in oklch, var(--accent) 40%, transparent); }
+.cx-filter-input::placeholder { color: var(--fg-subtle); }
+.cx-filter-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 2px; }
+.cx-filter-actions .cx-btn { height: 28px; padding: 0 12px; font-size: 12px; }
+
 /* Buttons */
 .cx-btn {
   display: inline-flex; align-items: center; justify-content: center; gap: 6px;

--- a/app/src/lib/filter.test.ts
+++ b/app/src/lib/filter.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearDimension,
+  docMatchesFilter,
+  filterChips,
+  isFilterEmpty,
+  normalizeFilter,
+} from "./filter";
+
+describe("isFilterEmpty", () => {
+  it("is true for {} and whitespace-only dimensions", () => {
+    expect(isFilterEmpty({})).toBe(true);
+    expect(isFilterEmpty({ author: "  ", path: "" })).toBe(true);
+  });
+  it("is false once any dimension is set", () => {
+    expect(isFilterEmpty({ yearMin: 1900 })).toBe(false);
+    expect(isFilterEmpty({ author: "twain" })).toBe(false);
+  });
+});
+
+describe("normalizeFilter", () => {
+  it("trims, drops empties, and returns undefined when nothing remains", () => {
+    expect(normalizeFilter({ author: "  ", path: "" })).toBeUndefined();
+    expect(normalizeFilter({ author: "  Twain  ", yearMin: 1880 })).toEqual({
+      author: "Twain",
+      yearMin: 1880,
+    });
+  });
+});
+
+describe("filterChips", () => {
+  it("renders one chip per active dimension with open-ended year bounds", () => {
+    expect(filterChips({ yearMin: 1800, yearMax: 1950 })).toEqual([
+      { key: "year", label: "year: 1800–1950" },
+    ]);
+    expect(filterChips({ yearMin: 1800 })[0].label).toBe("year: 1800–…");
+    expect(filterChips({ author: "Austen", path: "fiction" }).map((c) => c.key)).toEqual([
+      "author",
+      "path",
+    ]);
+  });
+});
+
+describe("clearDimension", () => {
+  it("removes both year bounds together, others individually", () => {
+    expect(clearDimension({ yearMin: 1, yearMax: 2, author: "x" }, "year")).toEqual({ author: "x" });
+    expect(clearDimension({ author: "x", path: "y" }, "author")).toEqual({ path: "y" });
+  });
+});
+
+describe("docMatchesFilter", () => {
+  const doc = { path: "corpus/fiction/austen-pp.txt", author: "Jane Austen", year: 1813 };
+  it("matches everything with no filter", () => {
+    expect(docMatchesFilter(doc, undefined)).toBe(true);
+  });
+  it("applies year range and excludes undated docs", () => {
+    expect(docMatchesFilter(doc, { yearMin: 1800, yearMax: 1820 })).toBe(true);
+    expect(docMatchesFilter(doc, { yearMin: 1900 })).toBe(false);
+    expect(docMatchesFilter({ ...doc, year: null }, { yearMin: 1800 })).toBe(false);
+  });
+  it("matches author and path case-insensitively as substrings", () => {
+    expect(docMatchesFilter(doc, { author: "austen" })).toBe(true);
+    expect(docMatchesFilter(doc, { author: "dickens" })).toBe(false);
+    expect(docMatchesFilter(doc, { path: "FICTION" })).toBe(true);
+    expect(docMatchesFilter(doc, { path: "legal" })).toBe(false);
+  });
+});

--- a/app/src/lib/filter.ts
+++ b/app/src/lib/filter.ts
@@ -1,0 +1,81 @@
+// Helpers for the document-metadata query filter: emptiness checks,
+// normalization (trim + drop empty dimensions), and the chip list the
+// QueryBar renders. The same `DocFilter` shape travels to the backend.
+
+import type { DocFilter } from "@/types";
+
+export function isFilterEmpty(f: DocFilter): boolean {
+  return (
+    f.yearMin == null &&
+    f.yearMax == null &&
+    !f.author?.trim() &&
+    !f.path?.trim()
+  );
+}
+
+/** Trim strings and drop empty dimensions. Returns `undefined` when
+ *  nothing is set, so query requests omit `filter` entirely (the backend
+ *  treats an absent filter as "whole corpus"). */
+export function normalizeFilter(f: DocFilter): DocFilter | undefined {
+  const out: DocFilter = {};
+  if (f.yearMin != null) out.yearMin = f.yearMin;
+  if (f.yearMax != null) out.yearMax = f.yearMax;
+  if (f.author?.trim()) out.author = f.author.trim();
+  if (f.path?.trim()) out.path = f.path.trim();
+  return isFilterEmpty(out) ? undefined : out;
+}
+
+export type FilterDimension = "year" | "author" | "path";
+
+export interface FilterChip {
+  key: FilterDimension;
+  label: string;
+}
+
+/** One chip per active dimension, for display in the query bar. */
+export function filterChips(f: DocFilter): FilterChip[] {
+  const chips: FilterChip[] = [];
+  if (f.yearMin != null || f.yearMax != null) {
+    const lo = f.yearMin != null ? String(f.yearMin) : "…";
+    const hi = f.yearMax != null ? String(f.yearMax) : "…";
+    chips.push({ key: "year", label: `year: ${lo}–${hi}` });
+  }
+  if (f.author?.trim()) chips.push({ key: "author", label: `author: ${f.author.trim()}` });
+  if (f.path?.trim()) chips.push({ key: "path", label: `path: ${f.path.trim()}` });
+  return chips;
+}
+
+/** Client-side mirror of the backend predicate, for views that join a
+ *  document list locally (e.g. frequency-over-time, which needs the
+ *  subcorpus token denominator). Keep in sync with `DocFilter::matches`
+ *  in corpust-index. */
+export function docMatchesFilter(
+  doc: { path: string; author: string | null; year: number | null },
+  f?: DocFilter,
+): boolean {
+  if (!f) return true;
+  if (f.yearMin != null || f.yearMax != null) {
+    if (doc.year == null) return false;
+    if (f.yearMin != null && doc.year < f.yearMin) return false;
+    if (f.yearMax != null && doc.year > f.yearMax) return false;
+  }
+  if (f.author?.trim() && !doc.author?.toLowerCase().includes(f.author.trim().toLowerCase())) {
+    return false;
+  }
+  if (f.path?.trim() && !doc.path.toLowerCase().includes(f.path.trim().toLowerCase())) {
+    return false;
+  }
+  return true;
+}
+
+/** Drop one dimension from a filter (chip ✕). */
+export function clearDimension(f: DocFilter, key: FilterDimension): DocFilter {
+  const next = { ...f };
+  if (key === "year") {
+    delete next.yearMin;
+    delete next.yearMax;
+  } else {
+    delete next[key];
+  }
+  return next;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -8,6 +8,7 @@ import type {
   BuildRequest,
   Collocate,
   CorpusMeta,
+  DocFilter,
   KwicRequest,
   QueryLayer,
 } from "@/types";
@@ -21,6 +22,7 @@ export interface CollocatesRequest {
   /** Tokens to consider on the right of the node. 0 = skip right. */
   rightWindow: number;
   limit: number;
+  filter?: DocFilter;
 }
 
 export interface CollocatesResult {
@@ -68,6 +70,7 @@ export interface FrequenciesRequest {
   corpusId: string;
   layer: QueryLayer;
   limit: number;
+  filter?: DocFilter;
 }
 
 export interface FreqResultRow {
@@ -87,6 +90,7 @@ export interface TermDistRequest {
   term: string;
   layer: QueryLayer;
   buckets: number;
+  filter?: DocFilter;
 }
 
 export interface DocTermCount {
@@ -111,6 +115,7 @@ export interface CollocateDistanceRequest {
   leftWindow: number;
   rightWindow: number;
   limit: number;
+  filter?: DocFilter;
 }
 
 export interface DistanceRow {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -24,6 +24,18 @@ export interface CorpusMeta {
 
 export type QueryLayer = "word" | "lemma" | "pos";
 
+/** Document-metadata filter applied to every query so KWIC / collocations
+ *  / frequency / dispersion all see the same subcorpus. Every dimension is
+ *  optional; an all-empty filter (or `undefined`) matches the whole corpus.
+ *  Author / path are case-insensitive substring matches; the year range is
+ *  inclusive and excludes documents with no detected year. */
+export interface DocFilter {
+  yearMin?: number;
+  yearMax?: number;
+  author?: string;
+  path?: string;
+}
+
 export interface KwicRequest {
   corpusId: string;
   term: string;
@@ -32,6 +44,7 @@ export interface KwicRequest {
   limit: number;
   /** Hits to skip before this page (concordance pagination). */
   offset?: number;
+  filter?: DocFilter;
 }
 
 export interface KwicHit {

--- a/crates/corpust-index/src/lib.rs
+++ b/crates/corpust-index/src/lib.rs
@@ -803,15 +803,14 @@ impl CorpusIndex {
         filter: Option<&DocFilter>,
     ) -> Result<FreqTable> {
         let allowed = self.resolve_filter(filter)?;
-        if allowed.is_none() {
-            if let Some(cached) = self
+        if allowed.is_none()
+            && let Some(cached) = self
                 .freq_cache
                 .lock()
                 .expect("freq_cache poisoned")
                 .get(&(layer, limit))
-            {
-                return Ok(cached.clone());
-            }
+        {
+            return Ok(cached.clone());
         }
         let searcher = self.reader.searcher();
         let field = self.layer_field(layer);
@@ -1035,15 +1034,14 @@ impl CorpusIndex {
             QueryLayer::Pos => (self.fields.body_pos, term.to_string()),
         };
         let cache_key = (lookup_term.clone(), layer, left, right);
-        if allowed.is_none() {
-            if let Some(cached) = self
+        if allowed.is_none()
+            && let Some(cached) = self
                 .colloc_cache
                 .lock()
                 .expect("colloc_cache poisoned")
                 .get(&cache_key)
-            {
-                return Ok(cached.clone());
-            }
+        {
+            return Ok(cached.clone());
         }
 
         let searcher = self.reader.searcher();
@@ -1297,15 +1295,14 @@ impl CorpusIndex {
         let allowed = self.resolve_filter(filter)?;
         let buckets = buckets.max(1);
         let cache_key = (term.to_string(), layer, buckets);
-        if allowed.is_none() {
-            if let Some(cached) = self
+        if allowed.is_none()
+            && let Some(cached) = self
                 .dist_cache
                 .lock()
                 .expect("dist_cache poisoned")
                 .get(&cache_key)
-            {
-                return Ok(cached.clone());
-            }
+        {
+            return Ok(cached.clone());
         }
         let searcher = self.reader.searcher();
         let field = self.layer_field(layer);
@@ -1352,11 +1349,11 @@ impl CorpusIndex {
                     Some(col) => col.first(doc).unwrap_or(0),
                     None => self.stored_doc_id(&searcher, seg_ord, doc)?,
                 };
-                if let Some(set) = &allowed {
-                    if !set.contains(&stored_id) {
-                        postings.advance();
-                        continue;
-                    }
+                if let Some(set) = &allowed
+                    && !set.contains(&stored_id)
+                {
+                    postings.advance();
+                    continue;
                 }
                 let freq = postings.term_freq() as u64;
                 *doc_hits.entry(stored_id).or_default() += freq;
@@ -2322,7 +2319,12 @@ by Mary Wollstonecraft (Godwin) Shelley
         }
     }
 
-    fn doc_info(doc_id: DocId, path: &str, author: Option<&str>, year: Option<u32>) -> DocumentInfo {
+    fn doc_info(
+        doc_id: DocId,
+        path: &str,
+        author: Option<&str>,
+        year: Option<u32>,
+    ) -> DocumentInfo {
         DocumentInfo {
             doc_id,
             path: PathBuf::from(path),

--- a/crates/corpust-index/src/lib.rs
+++ b/crates/corpust-index/src/lib.rs
@@ -22,11 +22,12 @@ use anyhow::{Context, Result};
 use corpust_annotate::{AnnotatedToken, Annotator};
 use corpust_core::{DocId, Document};
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use tantivy::{
-    DocAddress, DocSet, Index, IndexReader, ReloadPolicy, TERMINATED, TantivyDocument, Term, doc,
+    DocAddress, DocSet, Index, IndexReader, ReloadPolicy, Searcher, TERMINATED, TantivyDocument,
+    Term, doc,
     postings::Postings,
     schema::{
         BytesOptions, FAST, Field, IndexRecordOption, STORED, Schema, TextFieldIndexing,
@@ -152,6 +153,64 @@ pub struct DocMetadata {
     pub title: Option<String>,
     pub author: Option<String>,
     pub year: Option<u32>,
+}
+
+/// A metadata predicate over documents, applied to every query so KWIC /
+/// collocations / frequency / dispersion all see the same subcorpus.
+/// Every dimension is optional; an empty filter matches all documents.
+///
+/// Filtering is post-hoc: the predicate is evaluated against the cached
+/// [`DocumentInfo`] list to produce an allowed `doc_id` set, which the
+/// scan loops consult. Author / path are case-insensitive substring
+/// matches; year is an inclusive range. Documents missing a year are
+/// excluded by any year bound (we never guess).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DocFilter {
+    pub year_min: Option<u32>,
+    pub year_max: Option<u32>,
+    pub author: Option<String>,
+    pub path: Option<String>,
+}
+
+impl DocFilter {
+    /// True when no dimension constrains anything — the hot path skips
+    /// allow-set construction and stays exactly as fast as before.
+    pub fn is_empty(&self) -> bool {
+        self.year_min.is_none()
+            && self.year_max.is_none()
+            && self.author.as_deref().is_none_or(str::is_empty)
+            && self.path.as_deref().is_none_or(str::is_empty)
+    }
+
+    /// Whether a single document satisfies every active dimension.
+    pub fn matches(&self, d: &DocumentInfo) -> bool {
+        if self.year_min.is_some() || self.year_max.is_some() {
+            let Some(y) = d.year else { return false };
+            if self.year_min.is_some_and(|lo| y < lo) {
+                return false;
+            }
+            if self.year_max.is_some_and(|hi| y > hi) {
+                return false;
+            }
+        }
+        if let Some(a) = self.author.as_deref().filter(|s| !s.is_empty()) {
+            let needle = a.to_lowercase();
+            if !d
+                .author
+                .as_deref()
+                .is_some_and(|da| da.to_lowercase().contains(&needle))
+            {
+                return false;
+            }
+        }
+        if let Some(p) = self.path.as_deref().filter(|s| !s.is_empty()) {
+            let needle = p.to_lowercase();
+            if !d.path.to_string_lossy().to_lowercase().contains(&needle) {
+                return false;
+            }
+        }
+        true
+    }
 }
 
 /// Per-document occurrence count of a term.
@@ -467,6 +526,22 @@ impl CorpusIndex {
         limit: usize,
         offset: usize,
     ) -> Result<KwicPage> {
+        self.kwic_filtered(term, layer, context, limit, offset, None)
+    }
+
+    /// [`Self::kwic`] restricted to documents matching `filter`. Both the
+    /// page and the total count (paging denominator) reflect only the
+    /// matching subcorpus.
+    pub fn kwic_filtered(
+        &self,
+        term: &str,
+        layer: QueryLayer,
+        context: usize,
+        limit: usize,
+        offset: usize,
+        filter: Option<&DocFilter>,
+    ) -> Result<KwicPage> {
+        let allowed = self.resolve_filter(filter)?;
         let searcher = self.reader.searcher();
         let (query_field, lookup_term) = match layer {
             QueryLayer::Word => (self.fields.body, term.to_lowercase()),
@@ -492,11 +567,24 @@ impl CorpusIndex {
             else {
                 continue;
             };
+            let doc_id_col = seg_reader.fast_fields().u64("doc_id").ok();
 
             loop {
                 let doc = postings.doc();
                 if doc == TERMINATED {
                     continue 'segments;
+                }
+                // Drop filtered-out docs before they reach the total — the
+                // paging denominator must count only the subcorpus.
+                if let Some(set) = &allowed {
+                    let sid = match &doc_id_col {
+                        Some(col) => col.first(doc).unwrap_or(0),
+                        None => self.stored_doc_id(&searcher, seg_ord, doc)?,
+                    };
+                    if !set.contains(&sid) {
+                        postings.advance();
+                        continue;
+                    }
                 }
                 let tf = postings.term_freq() as usize;
                 let doc_start = total;
@@ -658,6 +746,40 @@ impl CorpusIndex {
         Ok(out)
     }
 
+    /// The set of `doc_id`s satisfying `filter`. Cheap: a pass over the
+    /// cached document list. The query scans consult this set to restrict
+    /// results to the matching subcorpus. Returns an empty set if nothing
+    /// matches (every query then yields zero hits, as expected).
+    pub fn matching_doc_ids(&self, filter: &DocFilter) -> Result<HashSet<DocId>> {
+        let docs = self.list_documents()?;
+        Ok(docs
+            .iter()
+            .filter(|d| filter.matches(d))
+            .map(|d| d.doc_id)
+            .collect())
+    }
+
+    /// Resolve a filter to an allow-set, or `None` when the filter is
+    /// empty (the caller then skips all membership checks).
+    fn resolve_filter(&self, filter: Option<&DocFilter>) -> Result<Option<HashSet<DocId>>> {
+        match filter {
+            Some(f) if !f.is_empty() => Ok(Some(self.matching_doc_ids(f)?)),
+            _ => Ok(None),
+        }
+    }
+
+    /// Fallback `doc_id` lookup for indexes built before `doc_id` became a
+    /// FAST field: fetch the stored document and read it. Hit only when
+    /// the columnar accessor is unavailable; the FAST column is preferred.
+    fn stored_doc_id(&self, searcher: &Searcher, seg_ord: usize, doc: u32) -> Result<DocId> {
+        let doc_addr = DocAddress::new(seg_ord as u32, doc);
+        let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
+        Ok(retrieved
+            .get_first(self.fields.doc_id)
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0))
+    }
+
     /// Corpus-wide top-`limit` term frequencies on `layer`. Returns the
     /// `(term, count)` rows sorted by descending count, plus the grand
     /// total of (non-empty) token occurrences in the field — the
@@ -667,20 +789,37 @@ impl CorpusIndex {
     /// per term. Fine at the current scale; for billion-word corpora the
     /// table should be precomputed at build time instead.
     pub fn frequencies(&self, layer: QueryLayer, limit: usize) -> Result<FreqTable> {
-        if let Some(cached) = self
-            .freq_cache
-            .lock()
-            .expect("freq_cache poisoned")
-            .get(&(layer, limit))
-        {
-            return Ok(cached.clone());
+        self.frequencies_filtered(layer, limit, None)
+    }
+
+    /// [`Self::frequencies`] restricted to documents matching `filter`.
+    /// Counts (and the grand total) reflect only the matching subcorpus.
+    /// The corpus-wide cache is consulted only for the unfiltered case;
+    /// filtered scans always run fresh.
+    pub fn frequencies_filtered(
+        &self,
+        layer: QueryLayer,
+        limit: usize,
+        filter: Option<&DocFilter>,
+    ) -> Result<FreqTable> {
+        let allowed = self.resolve_filter(filter)?;
+        if allowed.is_none() {
+            if let Some(cached) = self
+                .freq_cache
+                .lock()
+                .expect("freq_cache poisoned")
+                .get(&(layer, limit))
+            {
+                return Ok(cached.clone());
+            }
         }
         let searcher = self.reader.searcher();
         let field = self.layer_field(layer);
         let mut totals: HashMap<String, u64> = HashMap::new();
         let mut grand_total: u64 = 0;
-        for seg_reader in searcher.segment_readers() {
+        for (seg_ord, seg_reader) in searcher.segment_readers().iter().enumerate() {
             let inv = seg_reader.inverted_index(field)?;
+            let doc_id_col = seg_reader.fast_fields().u64("doc_id").ok();
             let term_dict = inv.terms();
             let mut stream = term_dict.stream()?;
             while stream.advance() {
@@ -697,21 +836,39 @@ impl CorpusIndex {
                     if doc == TERMINATED {
                         break;
                     }
+                    if let Some(set) = &allowed {
+                        let sid = match &doc_id_col {
+                            Some(col) => col.first(doc).unwrap_or(0),
+                            None => self.stored_doc_id(&searcher, seg_ord, doc)?,
+                        };
+                        if !set.contains(&sid) {
+                            postings.advance();
+                            continue;
+                        }
+                    }
                     sum += postings.term_freq() as u64;
                     postings.advance();
                 }
                 grand_total += sum;
-                *totals.entry(key).or_default() += sum;
+                // A term may exist corpus-wide yet have zero hits inside
+                // the filtered subcorpus — don't surface it as a 0-count
+                // row. (Unfiltered, every term has sum > 0, so this is a
+                // no-op there.)
+                if sum > 0 {
+                    *totals.entry(key).or_default() += sum;
+                }
             }
         }
         let mut rows: Vec<(String, u64)> = totals.into_iter().collect();
         rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
         rows.truncate(limit);
         let result = (rows, grand_total);
-        self.freq_cache
-            .lock()
-            .expect("freq_cache poisoned")
-            .insert((layer, limit), result.clone());
+        if allowed.is_none() {
+            self.freq_cache
+                .lock()
+                .expect("freq_cache poisoned")
+                .insert((layer, limit), result.clone());
+        }
         Ok(result)
     }
 
@@ -738,6 +895,72 @@ impl CorpusIndex {
             total += seg_reader.inverted_index(field)?.total_num_tokens();
         }
         Ok(total)
+    }
+
+    /// [`Self::layer_total_tokens`] restricted to a filtered subcorpus —
+    /// the `N` denominator association scores need when a filter is
+    /// active. With a filter set, returns the summed word-layer token
+    /// count of the matching documents (collocate scoring is always on the
+    /// surface layer, so per-layer subcorpus totals aren't needed).
+    pub fn layer_total_tokens_filtered(
+        &self,
+        layer: QueryLayer,
+        filter: Option<&DocFilter>,
+    ) -> Result<u64> {
+        match self.resolve_filter(filter)? {
+            None => self.layer_total_tokens(layer),
+            Some(set) => Ok(self
+                .list_documents()?
+                .iter()
+                .filter(|d| set.contains(&d.doc_id))
+                .map(|d| d.token_count as u64)
+                .sum()),
+        }
+    }
+
+    /// [`Self::term_totals`] restricted to documents matching `filter`, so
+    /// the `f(collocate)` marginals are scoped to the same subcorpus as
+    /// the co-occurrence counts.
+    pub fn term_totals_filtered(
+        &self,
+        terms: &[String],
+        layer: QueryLayer,
+        filter: Option<&DocFilter>,
+    ) -> Result<HashMap<String, u64>> {
+        let Some(allowed) = self.resolve_filter(filter)? else {
+            return self.term_totals(terms, layer);
+        };
+        let searcher = self.reader.searcher();
+        let field = self.layer_field(layer);
+        let mut out: HashMap<String, u64> = HashMap::with_capacity(terms.len());
+        for term in terms {
+            let term_obj = Term::from_field_text(field, term);
+            let mut sum = 0u64;
+            for (seg_ord, seg_reader) in searcher.segment_readers().iter().enumerate() {
+                let inv = seg_reader.inverted_index(field)?;
+                let doc_id_col = seg_reader.fast_fields().u64("doc_id").ok();
+                if let Some(mut postings) =
+                    inv.read_postings(&term_obj, IndexRecordOption::WithFreqs)?
+                {
+                    loop {
+                        let doc = postings.doc();
+                        if doc == TERMINATED {
+                            break;
+                        }
+                        let sid = match &doc_id_col {
+                            Some(col) => col.first(doc).unwrap_or(0),
+                            None => self.stored_doc_id(&searcher, seg_ord, doc)?,
+                        };
+                        if allowed.contains(&sid) {
+                            sum += postings.term_freq() as u64;
+                        }
+                        postings.advance();
+                    }
+                }
+            }
+            out.insert(term.clone(), sum);
+        }
+        Ok(out)
     }
 
     /// Corpus-wide frequency of each given term on `layer`. Used to fetch
@@ -791,19 +1014,36 @@ impl CorpusIndex {
         right: usize,
         max_nodes: usize,
     ) -> Result<CollocateScan> {
+        self.collocate_counts_filtered(term, layer, left, right, max_nodes, None)
+    }
+
+    /// [`Self::collocate_counts`] restricted to documents matching
+    /// `filter`. The scan cache is used only for the unfiltered case.
+    pub fn collocate_counts_filtered(
+        &self,
+        term: &str,
+        layer: QueryLayer,
+        left: usize,
+        right: usize,
+        max_nodes: usize,
+        filter: Option<&DocFilter>,
+    ) -> Result<CollocateScan> {
+        let allowed = self.resolve_filter(filter)?;
         let (query_field, lookup_term) = match layer {
             QueryLayer::Word => (self.fields.body, term.to_lowercase()),
             QueryLayer::Lemma => (self.fields.body_lemma, term.to_lowercase()),
             QueryLayer::Pos => (self.fields.body_pos, term.to_string()),
         };
         let cache_key = (lookup_term.clone(), layer, left, right);
-        if let Some(cached) = self
-            .colloc_cache
-            .lock()
-            .expect("colloc_cache poisoned")
-            .get(&cache_key)
-        {
-            return Ok(cached.clone());
+        if allowed.is_none() {
+            if let Some(cached) = self
+                .colloc_cache
+                .lock()
+                .expect("colloc_cache poisoned")
+                .get(&cache_key)
+            {
+                return Ok(cached.clone());
+            }
         }
 
         let searcher = self.reader.searcher();
@@ -822,11 +1062,22 @@ impl CorpusIndex {
             else {
                 continue;
             };
+            let doc_id_col = seg_reader.fast_fields().u64("doc_id").ok();
 
             loop {
                 let doc = postings.doc();
                 if doc == TERMINATED {
                     continue 'segments;
+                }
+                if let Some(set) = &allowed {
+                    let sid = match &doc_id_col {
+                        Some(col) => col.first(doc).unwrap_or(0),
+                        None => self.stored_doc_id(&searcher, seg_ord, doc)?,
+                    };
+                    if !set.contains(&sid) {
+                        postings.advance();
+                        continue;
+                    }
                 }
 
                 let doc_addr = DocAddress::new(seg_ord as u32, doc);
@@ -873,10 +1124,12 @@ impl CorpusIndex {
             window_tokens,
             truncated,
         };
-        self.colloc_cache
-            .lock()
-            .expect("colloc_cache poisoned")
-            .insert(cache_key, scan.clone());
+        if allowed.is_none() {
+            self.colloc_cache
+                .lock()
+                .expect("colloc_cache poisoned")
+                .insert(cache_key, scan.clone());
+        }
         Ok(scan)
     }
 
@@ -893,6 +1146,21 @@ impl CorpusIndex {
         right: usize,
         max_nodes: usize,
     ) -> Result<DistanceProfile> {
+        self.collocate_by_distance_filtered(term, layer, left, right, max_nodes, None)
+    }
+
+    /// [`Self::collocate_by_distance`] restricted to documents matching
+    /// `filter`.
+    pub fn collocate_by_distance_filtered(
+        &self,
+        term: &str,
+        layer: QueryLayer,
+        left: usize,
+        right: usize,
+        max_nodes: usize,
+        filter: Option<&DocFilter>,
+    ) -> Result<DistanceProfile> {
+        let allowed = self.resolve_filter(filter)?;
         let (query_field, lookup_term) = match layer {
             QueryLayer::Word => (self.fields.body, term.to_lowercase()),
             QueryLayer::Lemma => (self.fields.body_lemma, term.to_lowercase()),
@@ -926,10 +1194,21 @@ impl CorpusIndex {
             else {
                 continue;
             };
+            let doc_id_col = seg_reader.fast_fields().u64("doc_id").ok();
             loop {
                 let doc = postings.doc();
                 if doc == TERMINATED {
                     continue 'segments;
+                }
+                if let Some(set) = &allowed {
+                    let sid = match &doc_id_col {
+                        Some(col) => col.first(doc).unwrap_or(0),
+                        None => self.stored_doc_id(&searcher, seg_ord, doc)?,
+                    };
+                    if !set.contains(&sid) {
+                        postings.advance();
+                        continue;
+                    }
                 }
                 let doc_addr = DocAddress::new(seg_ord as u32, doc);
                 let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
@@ -1000,15 +1279,33 @@ impl CorpusIndex {
         layer: QueryLayer,
         buckets: usize,
     ) -> Result<TermDistribution> {
+        self.term_distribution_filtered(term, layer, buckets, None)
+    }
+
+    /// [`Self::term_distribution`] restricted to documents matching
+    /// `filter`. The global position axis (and so the dispersion buckets)
+    /// stays over the whole corpus; only hits from matching documents are
+    /// counted, and `doc_counts` lists just those documents. The cache is
+    /// used only for the unfiltered case.
+    pub fn term_distribution_filtered(
+        &self,
+        term: &str,
+        layer: QueryLayer,
+        buckets: usize,
+        filter: Option<&DocFilter>,
+    ) -> Result<TermDistribution> {
+        let allowed = self.resolve_filter(filter)?;
         let buckets = buckets.max(1);
         let cache_key = (term.to_string(), layer, buckets);
-        if let Some(cached) = self
-            .dist_cache
-            .lock()
-            .expect("dist_cache poisoned")
-            .get(&cache_key)
-        {
-            return Ok(cached.clone());
+        if allowed.is_none() {
+            if let Some(cached) = self
+                .dist_cache
+                .lock()
+                .expect("dist_cache poisoned")
+                .get(&cache_key)
+            {
+                return Ok(cached.clone());
+            }
         }
         let searcher = self.reader.searcher();
         let field = self.layer_field(layer);
@@ -1053,15 +1350,14 @@ impl CorpusIndex {
                 }
                 let stored_id = match &doc_id_col {
                     Some(col) => col.first(doc).unwrap_or(0),
-                    None => {
-                        let doc_addr = DocAddress::new(seg_ord as u32, doc);
-                        let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
-                        retrieved
-                            .get_first(self.fields.doc_id)
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0)
-                    }
+                    None => self.stored_doc_id(&searcher, seg_ord, doc)?,
                 };
+                if let Some(set) = &allowed {
+                    if !set.contains(&stored_id) {
+                        postings.advance();
+                        continue;
+                    }
+                }
                 let freq = postings.term_freq() as u64;
                 *doc_hits.entry(stored_id).or_default() += freq;
                 total_hits += freq;
@@ -1097,10 +1393,12 @@ impl CorpusIndex {
             dispersion,
             total_hits,
         };
-        self.dist_cache
-            .lock()
-            .expect("dist_cache poisoned")
-            .insert(cache_key, result.clone());
+        if allowed.is_none() {
+            self.dist_cache
+                .lock()
+                .expect("dist_cache poisoned")
+                .insert(cache_key, result.clone());
+        }
         Ok(result)
     }
 
@@ -2022,6 +2320,105 @@ by Mary Wollstonecraft (Godwin) Shelley
                 m.year
             );
         }
+    }
+
+    fn doc_info(doc_id: DocId, path: &str, author: Option<&str>, year: Option<u32>) -> DocumentInfo {
+        DocumentInfo {
+            doc_id,
+            path: PathBuf::from(path),
+            token_count: 0,
+            title: None,
+            author: author.map(str::to_string),
+            year,
+        }
+    }
+
+    #[test]
+    fn doc_filter_empty_matches_everything() {
+        let f = DocFilter::default();
+        assert!(f.is_empty());
+        assert!(f.matches(&doc_info(0, "a.txt", None, None)));
+    }
+
+    #[test]
+    fn doc_filter_year_range_excludes_undated_and_out_of_range() {
+        let f = DocFilter {
+            year_min: Some(1850),
+            year_max: Some(1900),
+            ..Default::default()
+        };
+        assert!(!f.is_empty());
+        assert!(f.matches(&doc_info(0, "a.txt", None, Some(1875))));
+        assert!(!f.matches(&doc_info(1, "b.txt", None, Some(1801)))); // before range
+        assert!(!f.matches(&doc_info(2, "c.txt", None, Some(1950)))); // after range
+        assert!(!f.matches(&doc_info(3, "d.txt", None, None))); // undated never guessed
+    }
+
+    #[test]
+    fn doc_filter_author_and_path_are_case_insensitive_substrings() {
+        let author = DocFilter {
+            author: Some("austen".into()),
+            ..Default::default()
+        };
+        assert!(author.matches(&doc_info(0, "x.txt", Some("Jane Austen"), None)));
+        assert!(!author.matches(&doc_info(1, "x.txt", Some("Charles Dickens"), None)));
+        assert!(!author.matches(&doc_info(2, "x.txt", None, None)));
+
+        let path = DocFilter {
+            path: Some("FICTION".into()),
+            ..Default::default()
+        };
+        assert!(path.matches(&doc_info(0, "corpus/fiction/a.txt", None, None)));
+        assert!(!path.matches(&doc_info(1, "corpus/legal/b.txt", None, None)));
+    }
+
+    #[test]
+    fn filtered_kwic_and_frequencies_restrict_to_the_subcorpus() {
+        let tmp = tempdir();
+        let idx = CorpusIndex::create(&tmp).unwrap();
+        idx.add_documents(
+            [
+                Document {
+                    id: 0,
+                    path: PathBuf::from("alpha.txt"),
+                    text: "the lazy dog sat".to_string(),
+                },
+                Document {
+                    id: 1,
+                    path: PathBuf::from("beta.txt"),
+                    text: "the lazy cat ran".to_string(),
+                },
+            ],
+            None,
+        )
+        .unwrap();
+
+        // Unfiltered: "the" occurs in both documents.
+        let all = idx.kwic("the", QueryLayer::Word, 2, 10, 0).unwrap();
+        assert_eq!(all.total, 2);
+
+        // Path filter to just alpha.txt → only that document's hit, and
+        // the total (paging denominator) reflects the subcorpus too.
+        let only_alpha = DocFilter {
+            path: Some("alpha".into()),
+            ..Default::default()
+        };
+        let page = idx
+            .kwic_filtered("the", QueryLayer::Word, 2, 10, 0, Some(&only_alpha))
+            .unwrap();
+        assert_eq!(page.total, 1);
+        assert_eq!(page.hits.len(), 1);
+        assert!(page.hits[0].path.to_string_lossy().contains("alpha"));
+
+        // Frequencies respect the same filter: "cat" only exists in beta,
+        // so it must be absent from an alpha-only frequency table.
+        let (rows, _total) = idx
+            .frequencies_filtered(QueryLayer::Word, 100, Some(&only_alpha))
+            .unwrap();
+        assert!(rows.iter().any(|(w, _)| w == "dog"));
+        assert!(!rows.iter().any(|(w, _)| w == "cat"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     fn tempdir() -> std::path::PathBuf {

--- a/crates/corpust-query/src/lib.rs
+++ b/crates/corpust-query/src/lib.rs
@@ -6,9 +6,9 @@
 //! callers' import paths.
 
 use anyhow::Result;
-use corpust_index::{CorpusIndex, DEFAULT_CONTEXT, DEFAULT_LIMIT, KwicPage, QueryLayer};
+use corpust_index::{CorpusIndex, DEFAULT_CONTEXT, DEFAULT_LIMIT, DocFilter, KwicPage, QueryLayer};
 
-pub use corpust_index::QueryLayer as Layer;
+pub use corpust_index::{DocFilter as Filter, QueryLayer as Layer};
 
 /// Parameters for a KWIC query.
 #[derive(Debug, Clone)]
@@ -19,6 +19,9 @@ pub struct KwicRequest<'a> {
     pub limit: usize,
     /// Hits to skip before the page — for concordance pagination.
     pub offset: usize,
+    /// Document-metadata filter; an empty filter (the default) matches
+    /// the whole corpus.
+    pub filter: DocFilter,
 }
 
 impl<'a> KwicRequest<'a> {
@@ -29,11 +32,17 @@ impl<'a> KwicRequest<'a> {
             context: DEFAULT_CONTEXT,
             limit: DEFAULT_LIMIT,
             offset: 0,
+            filter: DocFilter::default(),
         }
     }
 
     pub fn layer(mut self, layer: QueryLayer) -> Self {
         self.layer = layer;
+        self
+    }
+
+    pub fn filter(mut self, filter: DocFilter) -> Self {
+        self.filter = filter;
         self
     }
 
@@ -54,12 +63,14 @@ impl<'a> KwicRequest<'a> {
 }
 
 pub fn kwic(index: &CorpusIndex, request: KwicRequest<'_>) -> Result<KwicPage> {
-    index.kwic(
+    let filter = (!request.filter.is_empty()).then_some(&request.filter);
+    index.kwic_filtered(
         request.term,
         request.layer,
         request.context,
         request.limit,
         request.offset,
+        filter,
     )
 }
 


### PR DESCRIPTION
Implements the real query filter — replaces the dummy chip removed in #48 with a working metadata filter wired through the whole query stack. Closes #30.

Filter by **year range**, **author**, or **document-path substring**; KWIC, collocations, frequency, dispersion, distance, and over-time all respect the active filter. No re-indexing needed — year/author/path are already stored per document, so filtering is a post-hoc doc-id allowlist over the cached document list.

## Backend (`corpust-index`)
- `DocFilter { year_min, year_max, author, path }` + `matching_doc_ids` → allowed doc-id set.
- `*_filtered` variants of `kwic` / `frequencies` / `collocate_counts` / `collocate_by_distance` / `term_distribution` skip non-matching docs (via the `doc_id` FAST column) and bypass result caches when a filter is active. The unfiltered methods delegate, so the hot path is byte-for-byte unchanged.
- Filtered marginals (`layer_total_tokens_filtered` / `term_totals_filtered`) keep collocation association scores scoped to the subcorpus.

## Plumbing
- `corpust-query` `KwicRequest` grows `.filter()`; the five Tauri request DTOs grow an optional `filter` that converts into `DocFilter`. `frequencies` skips its precomputed corpus-wide sidecar when filtered.

## Frontend
- `DocFilter` type + optional `filter` on every request; `App` threads the normalized filter into all six query paths.
- `QueryBar` gains a real `+ filter` popover (year from/to, author contains, path contains) and removable chips. **Gated on `hasLiveData`** — it never appears, and never lies, on fixture/preview corpora (the exact problem #30 flagged).
- frequency-over-time filters its local doc list too, so the per-year token denominator matches the subcorpus.

## Verification
- Rust: index 29 / query 4 / tauri 4 tests; cargo check workspace green. New: filter unit tests + a filtered kwic/frequencies integration test.
- Frontend: **72 vitest** (added filter-logic + QueryBar interaction tests) + `tsc`/`vite build` green.
- Visually confirmed the popover + chips render correctly, and that the control is hidden on non-live corpora.

closes #30