### PR TITLE
CQL query engine — token-attribute, regex, multi-token queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,7 @@ dependencies = [
  "corpust-core",
  "corpust-tokenize",
  "rayon",
+ "regex",
  "tantivy",
  "unicode-segmentation",
 ]
@@ -779,6 +780,7 @@ dependencies = [
  "corpust-annotate",
  "corpust-core",
  "corpust-index",
+ "regex",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = "1"
 clap = { version = "4.5", features = ["derive"] }
 directories = "5"
 rayon = "1.10"
+regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tantivy = "0.26"

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -25,6 +25,19 @@ use tauri::{AppHandle, Emitter, Manager, State};
 
 const PROGRESS_EVENT: &str = "build:progress";
 
+/// Parse `term` as CQL when it looks like a CQL query, else `None` (a bare
+/// term keeps the classic single-layer path). A parse error becomes a
+/// user-facing command error.
+fn parse_cql_opt(term: &str) -> Result<Option<corpust_index::CqlQuery>, String> {
+    if corpust_query::is_cql(term) {
+        corpust_query::parse_cql(term)
+            .map(Some)
+            .map_err(|e| format!("query error: {e:#}"))
+    } else {
+        Ok(None)
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct BuildProgress {
@@ -174,20 +187,26 @@ fn run_collocates_inner(
     let limit = req.limit.clamp(1, 200);
     let span = (lw + rw) as u64;
     let filter = DocFilterDto::resolve(req.filter.clone());
+    let cql = parse_cql_opt(&req.term)?;
     let t0 = Instant::now();
 
     let (collocates, node_freq, window_tokens, truncated) =
         with_corpus(state, &req.corpus_id, |index| {
-            let scan = index
-                .collocate_counts_filtered(
-                    &req.term,
-                    layer,
-                    lw,
-                    rw,
-                    MAX_NODE_OCCURRENCES,
-                    Some(&filter),
-                )
-                .map_err(|e| format!("collocate scan failed: {e:#}"))?;
+            let scan = match &cql {
+                Some(q) => index
+                    .cql_collocate_counts(q, lw, rw, Some(&filter))
+                    .map_err(|e| format!("collocate scan failed: {e:#}"))?,
+                None => index
+                    .collocate_counts_filtered(
+                        &req.term,
+                        layer,
+                        lw,
+                        rw,
+                        MAX_NODE_OCCURRENCES,
+                        Some(&filter),
+                    )
+                    .map_err(|e| format!("collocate scan failed: {e:#}"))?,
+            };
 
             // Corpus size and collocate marginals are taken on the
             // surface (word) layer — collocates are surface forms read
@@ -200,9 +219,13 @@ fn run_collocates_inner(
             // candidate pool rather than every distinct collocate type
             // (which can be tens of thousands for a frequent node).
             let pool = (limit * 8).max(200);
-            // Exclude the node from its own collocate list (it co-occurs
-            // with itself within the window, e.g. "the Jew … the Jew").
-            let node_word = req.term.trim().to_lowercase();
+            // Exclude the node from its own collocate list (bare-term only;
+            // a CQL span has no single node word to exclude).
+            let node_word = if cql.is_some() {
+                String::new()
+            } else {
+                req.term.trim().to_lowercase()
+            };
             let mut cand: Vec<(String, u32, u32)> = scan
                 .counts
                 .iter()
@@ -444,11 +467,19 @@ fn run_term_distribution_inner(
 ) -> Result<TermDistResult, String> {
     let buckets = req.buckets.clamp(1, 1000);
     let filter = DocFilterDto::resolve(req.filter.clone());
+    let cql = parse_cql_opt(&req.term)?;
     let t0 = Instant::now();
     let dist = with_corpus(state, &req.corpus_id, |index| {
-        index
-            .term_distribution_filtered(&req.term, req.layer.into(), buckets, Some(&filter))
-            .map_err(|e| format!("term distribution failed: {e:#}"))
+        match &cql {
+            Some(q) => index.cql_term_distribution(q, buckets, Some(&filter)),
+            None => index.term_distribution_filtered(
+                &req.term,
+                req.layer.into(),
+                buckets,
+                Some(&filter),
+            ),
+        }
+        .map_err(|e| format!("term distribution failed: {e:#}"))
     })?;
     Ok(TermDistResult {
         doc_counts: dist
@@ -495,20 +526,30 @@ fn run_collocate_distance_inner(
     let layer: QueryLayer = req.layer.into();
     let limit = req.limit.clamp(1, 60);
     let filter = DocFilterDto::resolve(req.filter.clone());
+    let cql = parse_cql_opt(&req.term)?;
     let t0 = Instant::now();
 
     let (offsets, mut rows, node_freq, truncated) = with_corpus(state, &req.corpus_id, |index| {
-        let prof = index
-            .collocate_by_distance_filtered(
-                &req.term,
-                layer,
-                lw,
-                rw,
-                MAX_NODE_OCCURRENCES,
-                Some(&filter),
-            )
-            .map_err(|e| format!("distance scan failed: {e:#}"))?;
-        let node_word = req.term.trim().to_lowercase();
+        let prof = match &cql {
+            Some(q) => index
+                .cql_collocate_by_distance(q, lw, rw, Some(&filter))
+                .map_err(|e| format!("distance scan failed: {e:#}"))?,
+            None => index
+                .collocate_by_distance_filtered(
+                    &req.term,
+                    layer,
+                    lw,
+                    rw,
+                    MAX_NODE_OCCURRENCES,
+                    Some(&filter),
+                )
+                .map_err(|e| format!("distance scan failed: {e:#}"))?,
+        };
+        let node_word = if cql.is_some() {
+            String::new()
+        } else {
+            req.term.trim().to_lowercase()
+        };
         let rows: Vec<DistanceRow> = prof
             .rows
             .into_iter()

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -23,6 +23,7 @@ import { Onboarding } from "@/components/analyses/Onboarding";
 import { CommandPalette, type CommandDef } from "@/components/overlays/CommandPalette";
 import { BuildDialog } from "@/components/overlays/BuildDialog";
 import { CORPORA, RECENT_QUERIES, pickHits } from "@/data";
+import { isCql } from "@/lib/cql";
 import { concordanceCsv, concordanceJson, saveText, slug } from "@/lib/export";
 import { normalizeFilter } from "@/lib/filter";
 import { makeDensity } from "@/lib/utils";
@@ -78,6 +79,8 @@ export function App() {
   // is set) that travels to the backend.
   const [filter, setFilter] = useState<DocFilter>({});
   const queryFilter = useMemo(() => normalizeFilter(filter), [filter]);
+  // A malformed CQL query's parse error, shown under the query bar.
+  const [queryError, setQueryError] = useState<string | null>(null);
   // Concordance scroll position (0–1), tracked from the KWIC column so the
   // hit-density gutter's thumb reflects where you actually are, and clicks
   // on the gutter scroll there.
@@ -135,6 +138,7 @@ export function App() {
     (corpus: CorpusMeta | null, q: string, lyr: QueryLayer, offset: number) => {
       if (!corpus || !q.trim()) {
         setResult(null);
+        setQueryError(null);
         setLoading(false);
         return;
       }
@@ -146,6 +150,7 @@ export function App() {
         if (myId === kwicReqRef.current) {
           setResult({ hits, elapsedMs: 0.2 + Math.random() * 1.6, truncated: false, total: hits.length, offset: 0 });
           setSelected(null);
+          setQueryError(null);
           setLoading(false);
         }
         return;
@@ -163,12 +168,16 @@ export function App() {
           }));
           setResult({ hits, elapsedMs: r.elapsedMs, truncated: r.truncated, total: r.total, offset: r.offset });
           setSelected(null);
+          setQueryError(null);
         })
         .catch((e) => {
           if (myId !== kwicReqRef.current) return;
           console.error("runKwic failed:", e);
           setResult({ hits: [], elapsedMs: 0, truncated: false, total: 0, offset: 0 });
           setSelected(null);
+          // Surface a malformed-CQL error in place of an empty table.
+          const msg = String(e).replace(/^.*?query error:\s*/i, "");
+          setQueryError(isCql(q) ? msg : null);
         })
         .finally(() => {
           if (myId === kwicReqRef.current) setLoading(false);
@@ -433,6 +442,12 @@ export function App() {
           onFilterChange={setFilter}
           filterable={!!activeCorpus && hasLiveData(activeCorpus.id)}
         />
+        {queryError && (
+          <div className="cx-query-error">
+            <span className="label">query error</span>
+            <span>{queryError}</span>
+          </div>
+        )}
         <ViewTabs view={subview} onView={setSubview} result={result} />
         <div className="cx-results-wrap">
           {subview === "kwic" && (

--- a/app/src/components/query/QueryBar.test.tsx
+++ b/app/src/components/query/QueryBar.test.tsx
@@ -36,6 +36,42 @@ describe("QueryBar filter", () => {
     expect(onFilterChange).toHaveBeenCalledWith({}); // year cleared
   });
 
+  it("flags a CQL query and mutes the layer toggle", () => {
+    const { container } = render(
+      <QueryBar
+        layer="word"
+        term={'[pos="NN"]'}
+        onLayer={vi.fn()}
+        onTerm={vi.fn()}
+        onRun={vi.fn()}
+        onOpenPalette={vi.fn()}
+        filter={{}}
+        onFilterChange={vi.fn()}
+        filterable={false}
+      />,
+    );
+    expect(screen.getByText("CQL")).toBeInTheDocument();
+    expect(container.querySelector(".cx-layer-toggle.is-muted")).not.toBeNull();
+  });
+
+  it("shows the layer hint for a bare term, not CQL", () => {
+    render(
+      <QueryBar
+        layer="word"
+        term="bank"
+        onLayer={vi.fn()}
+        onTerm={vi.fn()}
+        onRun={vi.fn()}
+        onOpenPalette={vi.fn()}
+        filter={{}}
+        onFilterChange={vi.fn()}
+        filterable={false}
+      />,
+    );
+    expect(screen.getByText("regex ok")).toBeInTheDocument();
+    expect(screen.queryByText("CQL")).toBeNull();
+  });
+
   it("opens the popover and commits a normalized filter on Apply", () => {
     const { onFilterChange } = setup();
     fireEvent.click(screen.getByRole("button", { name: /filter/i }));

--- a/app/src/components/query/QueryBar.tsx
+++ b/app/src/components/query/QueryBar.tsx
@@ -1,5 +1,6 @@
 import { Plus, Search, X } from "lucide-react";
 import { type FormEvent, useEffect, useState } from "react";
+import { isCql } from "@/lib/cql";
 import { clearDimension, filterChips, normalizeFilter } from "@/lib/filter";
 import type { DocFilter, QueryLayer } from "@/types";
 
@@ -45,10 +46,16 @@ export function QueryBar({
   };
 
   const chips = filterChips(filter);
+  // A CQL query spans layers itself, so the word/lemma/pos toggle no longer
+  // applies — dim it and flag the input as CQL.
+  const cql = isCql(term);
 
   return (
     <form onSubmit={submit} className="cx-querybar">
-      <div className="cx-layer-toggle" title="Linguistic query layer">
+      <div
+        className={`cx-layer-toggle ${cql ? "is-muted" : ""}`}
+        title={cql ? "Layer is ignored for CQL queries (the query sets it per token)" : "Linguistic query layer"}
+      >
         {LAYERS.map((l) => {
           const locked = l.value !== "word" && !annotated;
           return (
@@ -84,7 +91,9 @@ export function QueryBar({
           disabled={disabled}
           spellCheck={false}
         />
-        <div className="cx-input-suffix">{term && <span>{layer === "pos" ? "exact" : "regex ok"}</span>}</div>
+        <div className="cx-input-suffix">
+          {term && <span>{cql ? "CQL" : layer === "pos" ? "exact" : "regex ok"}</span>}
+        </div>
       </div>
 
       {filterable && (

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -311,7 +311,21 @@
   display: inline-flex;
   border: 1px solid var(--border); border-radius: 5px;
   padding: 2px; gap: 2px; background: var(--bg-inset);
+  transition: opacity var(--dur-1) var(--ease);
 }
+/* The layer toggle doesn't apply to a CQL query (it sets layers per token). */
+.cx-layer-toggle.is-muted { opacity: 0.4; }
+
+/* Inline query (CQL parse) error, shown under the query bar. */
+.cx-query-error {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 14px;
+  background: color-mix(in oklch, var(--danger) 14%, var(--bg-raised));
+  border-bottom: 1px solid color-mix(in oklch, var(--danger) 40%, transparent);
+  color: var(--fg);
+  font-family: var(--font-mono); font-size: 12px;
+}
+.cx-query-error .label { color: var(--danger); font-weight: 600; }
 .cx-layer {
   border: 0; background: transparent;
   font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);

--- a/app/src/lib/cql.test.ts
+++ b/app/src/lib/cql.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { isCql } from "./cql";
+
+describe("isCql", () => {
+  it("treats bracket and quote forms as CQL", () => {
+    expect(isCql('[pos="NN"]')).toBe(true);
+    expect(isCql('"bank"')).toBe(true);
+    expect(isCql('[word="a"] [word="b"]')).toBe(true);
+  });
+  it("leaves bare terms (incl. bare regex) as classic queries", () => {
+    expect(isCql("bank")).toBe(false);
+    expect(isCql("run.*")).toBe(false);
+    expect(isCql("")).toBe(false);
+  });
+});

--- a/app/src/lib/cql.ts
+++ b/app/src/lib/cql.ts
@@ -1,0 +1,8 @@
+// Whether a query string should be treated as CQL (token-attribute /
+// multi-token) rather than a bare single-layer term. Mirrors the backend
+// `corpust_query::is_cql` so the UI and engine agree on what's a CQL query.
+
+export function isCql(input: string): boolean {
+  const t = input.trimStart();
+  return t.startsWith("[") || t.startsWith('"') || input.includes("[");
+}

--- a/crates/corpust-index/Cargo.toml
+++ b/crates/corpust-index/Cargo.toml
@@ -13,5 +13,6 @@ corpust-tokenize.workspace = true
 corpust-annotate.workspace = true
 anyhow.workspace = true
 rayon.workspace = true
+regex.workspace = true
 tantivy.workspace = true
 unicode-segmentation.workspace = true

--- a/crates/corpust-index/src/cql.rs
+++ b/crates/corpust-index/src/cql.rs
@@ -1,0 +1,481 @@
+//! CQL (corpus query language) matching.
+//!
+//! A CQL query is a sequence of token patterns; each token pattern is a set
+//! of attribute constraints (`word` / `lemma` / `pos`) that must all hold at
+//! the same token position. Values can be exact or regex. A multi-token
+//! query matches a run of consecutive positions (token *i+1* at *p+1*).
+//!
+//! Because `body` / `body_lemma` / `body_pos` are indexed over one shared
+//! tokenisation, a position `p` denotes the same token on every layer — so
+//! a multi-attribute constraint is just an intersection of per-layer
+//! position sets at `p`. [`CorpusIndex::cql_scan`] is the shared primitive;
+//! the KWIC / collocation / distribution surfaces all consume it.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::Result;
+use regex::Regex;
+use tantivy::postings::Postings;
+use tantivy::schema::{IndexRecordOption, Value};
+use tantivy::{DocAddress, DocSet, TERMINATED, TantivyDocument, Term};
+
+use crate::{
+    CollocateScan, CorpusIndex, DistanceProfile, DocFilter, DocId, DocTermCount, KwicHit, KwicPage,
+    QueryLayer, Side, TermDistribution, bytes_to_offsets, normalize_token, window_side,
+    window_span,
+};
+
+/// Safety ceiling on matched spans for a single CQL scan — mirrors the
+/// collocation node ceiling. Broad patterns (`[pos="N.*"]`) stay bounded;
+/// callers surface the cut via a `truncated` flag.
+const MAX_SPANS: u64 = 1_000_000;
+
+/// One token's constraint on a single annotation layer.
+#[derive(Debug, Clone)]
+pub struct AttrConstraint {
+    pub layer: QueryLayer,
+    pub matcher: Matcher,
+}
+
+/// How an attribute value is matched against the indexed terms.
+#[derive(Debug, Clone)]
+pub enum Matcher {
+    /// Exact term (already cased for its layer: lowercased for word/lemma).
+    Exact(String),
+    /// Full-token-anchored regex (case-insensitive for word/lemma).
+    Regex(Regex),
+}
+
+/// One token position: every constraint must hold at the same position.
+#[derive(Debug, Clone)]
+pub struct TokenPattern {
+    pub constraints: Vec<AttrConstraint>,
+}
+
+/// A sequence of token patterns matched over consecutive positions.
+#[derive(Debug, Clone)]
+pub struct CqlQuery {
+    pub tokens: Vec<TokenPattern>,
+}
+
+impl CqlQuery {
+    pub fn span_len(&self) -> usize {
+        self.tokens.len()
+    }
+}
+
+/// Intersect several ascending-sorted position vectors into one.
+fn intersect_sorted(sets: &[&Vec<u32>]) -> Vec<u32> {
+    let Some((first, rest)) = sets.split_first() else {
+        return Vec::new();
+    };
+    let mut out: Vec<u32> = (*first).clone();
+    for s in rest {
+        let set: HashSet<u32> = s.iter().copied().collect();
+        out.retain(|p| set.contains(p));
+    }
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+impl CorpusIndex {
+    /// Drive `f` over every matching document, passing the matched span
+    /// start positions (token indices, ascending). Returns
+    /// `(total_spans, truncated)`. Stops once `MAX_SPANS` is reached.
+    ///
+    /// `f` receives `(doc_id, path, body, offsets, starts)`.
+    fn cql_scan(
+        &self,
+        query: &CqlQuery,
+        allowed: Option<&HashSet<DocId>>,
+        mut f: impl FnMut(DocId, &str, &str, &[u32], &[usize]),
+    ) -> Result<(u64, bool)> {
+        let span_len = query.span_len();
+        if span_len == 0 {
+            return Ok((0, false));
+        }
+        let searcher = self.reader.searcher();
+        let mut total: u64 = 0;
+        let mut truncated = false;
+
+        'segments: for (seg_ord, seg_reader) in searcher.segment_readers().iter().enumerate() {
+            // Resolve each (token, constraint) into a slot with positional
+            // postings for every matching term in this segment. `slot_accs`
+            // holds each slot's matched positions in the current document.
+            let mut slot_accs: Vec<Vec<u32>> = Vec::new();
+            let mut token_slots: Vec<Vec<usize>> = vec![Vec::new(); span_len];
+            // (slot index, postings cursor)
+            let mut cursors: Vec<(usize, tantivy::postings::SegmentPostings)> = Vec::new();
+
+            for (ti, token) in query.tokens.iter().enumerate() {
+                for constraint in &token.constraints {
+                    let field = self.layer_field(constraint.layer);
+                    let inv = seg_reader.inverted_index(field)?;
+                    // Resolve the constraint to matching term texts in this
+                    // segment's dictionary: Exact → the term itself (no
+                    // scan); Regex → stream the dictionary, keep full matches.
+                    let terms: Vec<String> = match &constraint.matcher {
+                        Matcher::Exact(t) => vec![t.clone()],
+                        Matcher::Regex(re) => {
+                            let mut out = Vec::new();
+                            let mut stream = inv.terms().stream()?;
+                            while stream.advance() {
+                                if let Ok(key) = std::str::from_utf8(stream.key())
+                                    && !key.is_empty()
+                                    && re.is_match(key)
+                                {
+                                    out.push(key.to_string());
+                                }
+                            }
+                            out
+                        }
+                    };
+                    let slot_id = slot_accs.len();
+                    let mut any = false;
+                    for term in &terms {
+                        let term_obj = Term::from_field_text(field, term);
+                        if let Some(postings) =
+                            inv.read_postings(&term_obj, IndexRecordOption::WithFreqsAndPositions)?
+                        {
+                            cursors.push((slot_id, postings));
+                            any = true;
+                        }
+                    }
+                    // A constraint with no present terms can never hold →
+                    // its token never matches → no hits in this segment.
+                    if !any {
+                        continue 'segments;
+                    }
+                    slot_accs.push(Vec::new());
+                    token_slots[ti].push(slot_id);
+                }
+            }
+            if cursors.is_empty() {
+                continue 'segments;
+            }
+
+            let doc_id_col = seg_reader.fast_fields().u64("doc_id").ok();
+            let mut posbuf: Vec<u32> = Vec::new();
+
+            loop {
+                // Smallest doc id any cursor is currently positioned at.
+                let mut min_doc = TERMINATED;
+                for (_, c) in &cursors {
+                    let d = c.doc();
+                    if d != TERMINATED && d < min_doc {
+                        min_doc = d;
+                    }
+                }
+                if min_doc == TERMINATED {
+                    break;
+                }
+
+                let stored_id = match &doc_id_col {
+                    Some(col) => col.first(min_doc).unwrap_or(0),
+                    None => self.stored_doc_id(&searcher, seg_ord, min_doc)?,
+                };
+                let keep = allowed.is_none_or(|set| set.contains(&stored_id));
+
+                if !keep {
+                    for (_, c) in &mut cursors {
+                        if c.doc() == min_doc {
+                            c.advance();
+                        }
+                    }
+                    continue;
+                }
+
+                for a in &mut slot_accs {
+                    a.clear();
+                }
+                for (slot, c) in &mut cursors {
+                    if c.doc() == min_doc {
+                        posbuf.clear();
+                        c.positions(&mut posbuf);
+                        slot_accs[*slot].extend_from_slice(&posbuf);
+                        c.advance();
+                    }
+                }
+
+                // Per-token positions = intersection of its constraint slots.
+                let token_pos: Vec<Vec<u32>> = (0..span_len)
+                    .map(|ti| {
+                        let refs: Vec<&Vec<u32>> =
+                            token_slots[ti].iter().map(|&s| &slot_accs[s]).collect();
+                        if refs.len() == 1 {
+                            let mut v = refs[0].clone();
+                            v.sort_unstable();
+                            v.dedup();
+                            v
+                        } else {
+                            intersect_sorted(&refs)
+                        }
+                    })
+                    .collect();
+
+                // Sequence match: p in token_pos[0] with p+i in token_pos[i].
+                let starts: Vec<usize> = if span_len == 1 {
+                    token_pos[0].iter().map(|&p| p as usize).collect()
+                } else {
+                    let later: Vec<HashSet<u32>> = token_pos[1..]
+                        .iter()
+                        .map(|v| v.iter().copied().collect())
+                        .collect();
+                    token_pos[0]
+                        .iter()
+                        .filter(|&&p0| {
+                            (1..span_len).all(|i| later[i - 1].contains(&(p0 + i as u32)))
+                        })
+                        .map(|&p| p as usize)
+                        .collect()
+                };
+
+                if !starts.is_empty() {
+                    let doc_addr = DocAddress::new(seg_ord as u32, min_doc);
+                    let retrieved: TantivyDocument = searcher.doc(doc_addr)?;
+                    let body = retrieved
+                        .get_first(self.fields.body)
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    let path = retrieved
+                        .get_first(self.fields.path)
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default();
+                    let offsets = bytes_to_offsets(
+                        retrieved
+                            .get_first(self.fields.token_offsets)
+                            .and_then(|v| v.as_bytes())
+                            .unwrap_or_default(),
+                    );
+                    f(stored_id, path, body, &offsets, &starts);
+                    total += starts.len() as u64;
+                    if total >= MAX_SPANS {
+                        truncated = true;
+                        break 'segments;
+                    }
+                }
+            }
+        }
+
+        Ok((total, truncated))
+    }
+
+    /// [`Self::kwic`] for a parsed CQL query. Hits are spans of
+    /// `query.span_len()` tokens; `total` counts all spans (subcorpus +
+    /// ceiling aware).
+    pub fn cql_kwic(
+        &self,
+        query: &CqlQuery,
+        context: usize,
+        limit: usize,
+        offset: usize,
+        filter: Option<&DocFilter>,
+    ) -> Result<KwicPage> {
+        let allowed = self.resolve_filter(filter)?;
+        let span_len = query.span_len();
+        let page_end = offset.saturating_add(limit);
+        let mut hits: Vec<KwicHit> = Vec::with_capacity(limit.min(512));
+        let mut idx: usize = 0;
+        let (total, _truncated) = self.cql_scan(
+            query,
+            allowed.as_ref(),
+            |doc_id, path, body, offsets, starts| {
+                for &p in starts {
+                    let gi = idx;
+                    idx += 1;
+                    if gi < offset || gi >= page_end {
+                        continue;
+                    }
+                    if let Some((left, hit, right)) =
+                        window_span(body, offsets, p, span_len, context)
+                    {
+                        hits.push(KwicHit {
+                            doc_id,
+                            path: std::path::PathBuf::from(path),
+                            hit_position: p,
+                            left,
+                            hit,
+                            right,
+                        });
+                    }
+                }
+            },
+        )?;
+        Ok(KwicPage {
+            hits,
+            total: total as usize,
+        })
+    }
+
+    /// [`Self::collocate_counts`] for a CQL query. The matched span is the
+    /// node: collocates are counted left of the span start and right of the
+    /// span end.
+    pub fn cql_collocate_counts(
+        &self,
+        query: &CqlQuery,
+        left: usize,
+        right: usize,
+        filter: Option<&DocFilter>,
+    ) -> Result<CollocateScan> {
+        let allowed = self.resolve_filter(filter)?;
+        let span_len = query.span_len();
+        let mut counts: HashMap<String, (u32, u32)> = HashMap::new();
+        let mut window_tokens: u64 = 0;
+        let (node_freq, truncated) = self.cql_scan(
+            query,
+            allowed.as_ref(),
+            |_doc, _path, body, offsets, starts| {
+                for &p in starts {
+                    let last = p + span_len - 1;
+                    for w in window_side(body, offsets, p, left, Side::Left) {
+                        counts.entry(w).or_default().0 += 1;
+                        window_tokens += 1;
+                    }
+                    for w in window_side(body, offsets, last, right, Side::Right) {
+                        counts.entry(w).or_default().1 += 1;
+                        window_tokens += 1;
+                    }
+                }
+            },
+        )?;
+        Ok(CollocateScan {
+            node_freq,
+            counts,
+            window_tokens,
+            truncated,
+        })
+    }
+
+    /// [`Self::collocate_by_distance`] for a CQL query. Distances are
+    /// measured from the span: `-k` is the token `k` before the span start,
+    /// `+k` the token `k` after the span end.
+    pub fn cql_collocate_by_distance(
+        &self,
+        query: &CqlQuery,
+        left: usize,
+        right: usize,
+        filter: Option<&DocFilter>,
+    ) -> Result<DistanceProfile> {
+        let allowed = self.resolve_filter(filter)?;
+        let span_len = query.span_len();
+        let offsets_axis: Vec<i32> = (1..=left as i32)
+            .rev()
+            .map(|d| -d)
+            .chain(1..=right as i32)
+            .collect();
+        let slot_of = |d: i32| -> usize {
+            if d < 0 {
+                (d + left as i32) as usize
+            } else {
+                left + (d as usize - 1)
+            }
+        };
+        let slots = left + right;
+        let mut rows: HashMap<String, Vec<u32>> = HashMap::new();
+        let (node_freq, truncated) = self.cql_scan(
+            query,
+            allowed.as_ref(),
+            |_doc, _path, body, offsets, starts| {
+                let n = offsets.len();
+                let start_of = |i: usize| -> usize {
+                    if i < n {
+                        offsets[i] as usize
+                    } else {
+                        body.len()
+                    }
+                };
+                for &p in starts {
+                    let last = p + span_len - 1;
+                    // left of the span start
+                    for k in 1..=left {
+                        if p < k {
+                            break;
+                        }
+                        let i = p - k;
+                        if let Some(w) = normalize_token(&body[start_of(i)..start_of(i + 1)]) {
+                            rows.entry(w).or_insert_with(|| vec![0u32; slots])
+                                [slot_of(-(k as i32))] += 1;
+                        }
+                    }
+                    // right of the span end
+                    for k in 1..=right {
+                        let i = last + k;
+                        if i >= n {
+                            break;
+                        }
+                        if let Some(w) = normalize_token(&body[start_of(i)..start_of(i + 1)]) {
+                            rows.entry(w).or_insert_with(|| vec![0u32; slots])
+                                [slot_of(k as i32)] += 1;
+                        }
+                    }
+                }
+            },
+        )?;
+        Ok(DistanceProfile {
+            node_freq,
+            offsets: offsets_axis,
+            rows,
+            truncated,
+        })
+    }
+
+    /// [`Self::term_distribution`] for a CQL query: per-document span counts
+    /// plus a dispersion histogram over the global position axis. The axis
+    /// stays whole-corpus; only matching documents contribute.
+    pub fn cql_term_distribution(
+        &self,
+        query: &CqlQuery,
+        buckets: usize,
+        filter: Option<&DocFilter>,
+    ) -> Result<TermDistribution> {
+        let allowed = self.resolve_filter(filter)?;
+        let buckets = buckets.max(1);
+        let docs = self.list_documents()?;
+        let mut global_start: HashMap<DocId, u64> = HashMap::new();
+        let mut cursor: u64 = 0;
+        for d in &docs {
+            global_start.insert(d.doc_id, cursor);
+            cursor += d.token_count as u64;
+        }
+        let total_tokens = cursor.max(1);
+
+        let mut dispersion = vec![0u32; buckets];
+        let mut doc_hits: HashMap<DocId, u64> = HashMap::new();
+        let mut total_hits: u64 = 0;
+        self.cql_scan(
+            query,
+            allowed.as_ref(),
+            |doc_id, _path, _body, _offsets, starts| {
+                *doc_hits.entry(doc_id).or_default() += starts.len() as u64;
+                total_hits += starts.len() as u64;
+                let base = *global_start.get(&doc_id).unwrap_or(&0);
+                for &p in starts {
+                    let global_pos = base + p as u64;
+                    let b = ((global_pos * buckets as u64) / total_tokens) as usize;
+                    dispersion[b.min(buckets - 1)] += 1;
+                }
+            },
+        )?;
+
+        let mut doc_counts: Vec<DocTermCount> = docs
+            .iter()
+            .filter_map(|d| {
+                let hits = *doc_hits.get(&d.doc_id).unwrap_or(&0);
+                (hits > 0).then(|| DocTermCount {
+                    doc_id: d.doc_id,
+                    path: d.path.clone(),
+                    hits,
+                    token_count: d.token_count as u64,
+                })
+            })
+            .collect();
+        doc_counts.sort_by(|a, b| b.hits.cmp(&a.hits).then_with(|| a.doc_id.cmp(&b.doc_id)));
+
+        Ok(TermDistribution {
+            doc_counts,
+            dispersion,
+            total_hits,
+        })
+    }
+}

--- a/crates/corpust-index/src/lib.rs
+++ b/crates/corpust-index/src/lib.rs
@@ -17,6 +17,8 @@
 //! context extraction is O(context) regardless of document length.
 
 pub mod assoc;
+mod cql;
+pub use cql::{AttrConstraint, CqlQuery, Matcher, TokenPattern};
 
 use anyhow::{Context, Result};
 use corpust_annotate::{AnnotatedToken, Annotator};
@@ -1477,20 +1479,33 @@ fn window(
     p: usize,
     context: usize,
 ) -> Option<(String, String, String)> {
+    window_span(body, offsets, p, 1, context)
+}
+
+/// Like [`window`] but the node spans `len` tokens starting at `start`
+/// (`len == 1` is a single-token hit). Powers multi-token CQL hits, where
+/// the matched span covers a sequence of token positions.
+///
+/// Slices each token directly by its stored byte offset. `offsets[i]` is
+/// the start of token `i`; the start of the next token (or end of body) is
+/// its end. This keeps the displayed hit aligned with the indexed
+/// positions even when the indexing tokenizer (an annotator's
+/// tokenisation) splits the text differently from a naive re-tokenisation.
+fn window_span(
+    body: &str,
+    offsets: &[u32],
+    start: usize,
+    len: usize,
+    context: usize,
+) -> Option<(String, String, String)> {
     let n = offsets.len();
-    if p >= n {
+    if start >= n || len == 0 {
         return None;
     }
-    let window_start = p.saturating_sub(context);
-    let window_end = (p + context + 1).min(n); // exclusive token index
+    let node_end = (start + len).min(n); // exclusive token index of the span
+    let window_start = start.saturating_sub(context);
+    let window_end = (node_end + context).min(n); // exclusive token index
 
-    // Slice each token directly by its stored byte offset. `offsets[i]` is
-    // the start of token `i`; the start of token `i+1` (or end of body) is
-    // its end. This keeps the displayed hit aligned with the indexed
-    // position `p` even when the indexing tokenizer (an annotator's
-    // tokenisation) splits the text differently from a naive
-    // re-tokenisation — re-tokenising here silently mis-aligned the hit on
-    // annotated corpora.
     let start_of = |i: usize| -> usize {
         if i < n {
             offsets[i] as usize
@@ -1498,9 +1513,9 @@ fn window(
             body.len()
         }
     };
-    let left = body[start_of(window_start)..start_of(p)].trim();
-    let hit = body[start_of(p)..start_of(p + 1)].trim();
-    let right = body[start_of(p + 1)..start_of(window_end)].trim();
+    let left = body[start_of(window_start)..start_of(start)].trim();
+    let hit = body[start_of(start)..start_of(node_end)].trim();
+    let right = body[start_of(node_end)..start_of(window_end)].trim();
 
     Some((left.to_owned(), hit.to_owned(), right.to_owned()))
 }
@@ -2419,6 +2434,203 @@ by Mary Wollstonecraft (Godwin) Shelley
             .unwrap();
         assert!(rows.iter().any(|(w, _)| w == "dog"));
         assert!(!rows.iter().any(|(w, _)| w == "cat"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Deterministic POS/lemma tagger for CQL tests: a fixed word→tag map,
+    /// lemma = lowercased word. Avoids depending on TreeTagger models.
+    struct MockTagger;
+
+    impl Annotator for MockTagger {
+        fn annotate<'a>(
+            &self,
+            text: &'a str,
+        ) -> anyhow::Result<Vec<corpust_annotate::AnnotatedToken<'a>>> {
+            use std::borrow::Cow;
+            Ok(text
+                .unicode_word_indices()
+                .enumerate()
+                .map(|(pos, (start, word))| {
+                    let tag = match word.to_lowercase().as_str() {
+                        "the" | "a" => "DT",
+                        "dog" | "cat" | "fox" => "NN",
+                        "lazy" | "quick" | "brown" => "JJ",
+                        _ => "XX",
+                    };
+                    corpust_annotate::AnnotatedToken {
+                        word: Cow::Borrowed(word),
+                        lemma: Some(Cow::Owned(word.to_lowercase())),
+                        pos: Some(Cow::Borrowed(tag)),
+                        byte_start: start,
+                        byte_end: start + word.len(),
+                        position: pos as corpust_core::Position,
+                    }
+                })
+                .collect())
+        }
+        fn supported_languages(&self) -> &[&'static str] {
+            &["*"]
+        }
+        fn id(&self) -> &str {
+            "mock"
+        }
+    }
+
+    fn pos(tag: &str) -> TokenPattern {
+        TokenPattern {
+            constraints: vec![AttrConstraint {
+                layer: QueryLayer::Pos,
+                matcher: Matcher::Exact(tag.to_string()),
+            }],
+        }
+    }
+    fn word(w: &str) -> AttrConstraint {
+        AttrConstraint {
+            layer: QueryLayer::Word,
+            matcher: Matcher::Exact(w.to_string()),
+        }
+    }
+
+    #[test]
+    fn cql_matches_pos_attribute_and_multi_token_sequences() {
+        let tmp = tempdir();
+        let idx = CorpusIndex::create(&tmp).unwrap();
+        idx.add_documents(
+            [Document {
+                id: 0,
+                path: PathBuf::from("a.txt"),
+                // the/DT quick/JJ brown/JJ fox/NN jumps/XX over/XX the/DT lazy/JJ dog/NN
+                text: "the quick brown fox jumps over the lazy dog".to_string(),
+            }],
+            Some(&MockTagger),
+        )
+        .unwrap();
+
+        // [pos="NN"] → fox, dog
+        let nn = idx
+            .cql_kwic(
+                &CqlQuery {
+                    tokens: vec![pos("NN")],
+                },
+                2,
+                50,
+                0,
+                None,
+            )
+            .unwrap();
+        assert_eq!(nn.total, 2);
+        assert!(nn.hits.iter().any(|h| h.hit == "fox"));
+        assert!(nn.hits.iter().any(|h| h.hit == "dog"));
+
+        // Multi-attribute: [word="the" pos="DT"] → 2; [word="the" pos="NN"] → 0
+        let the_dt = CqlQuery {
+            tokens: vec![TokenPattern {
+                constraints: vec![
+                    word("the"),
+                    AttrConstraint {
+                        layer: QueryLayer::Pos,
+                        matcher: Matcher::Exact("DT".into()),
+                    },
+                ],
+            }],
+        };
+        assert_eq!(idx.cql_kwic(&the_dt, 1, 50, 0, None).unwrap().total, 2);
+        let the_nn = CqlQuery {
+            tokens: vec![TokenPattern {
+                constraints: vec![
+                    word("the"),
+                    AttrConstraint {
+                        layer: QueryLayer::Pos,
+                        matcher: Matcher::Exact("NN".into()),
+                    },
+                ],
+            }],
+        };
+        assert_eq!(idx.cql_kwic(&the_nn, 1, 50, 0, None).unwrap().total, 0);
+
+        // Sequence [pos="DT"] [pos="JJ"] → "the quick", "the lazy"
+        let seq = idx
+            .cql_kwic(
+                &CqlQuery {
+                    tokens: vec![pos("DT"), pos("JJ")],
+                },
+                2,
+                50,
+                0,
+                None,
+            )
+            .unwrap();
+        assert_eq!(seq.total, 2);
+        assert!(seq.hits.iter().all(|h| h.hit.starts_with("the ")));
+
+        // Regex on POS: [pos="N.*"] → the two NN tokens
+        let re = CqlQuery {
+            tokens: vec![TokenPattern {
+                constraints: vec![AttrConstraint {
+                    layer: QueryLayer::Pos,
+                    matcher: Matcher::Regex(regex::Regex::new("^(?:N.*)$").unwrap()),
+                }],
+            }],
+        };
+        assert_eq!(idx.cql_kwic(&re, 2, 50, 0, None).unwrap().total, 2);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn cql_respects_the_document_filter() {
+        let tmp = tempdir();
+        let idx = CorpusIndex::create(&tmp).unwrap();
+        idx.add_documents(
+            [
+                Document {
+                    id: 0,
+                    path: PathBuf::from("alpha.txt"),
+                    text: "the lazy dog".into(),
+                },
+                Document {
+                    id: 1,
+                    path: PathBuf::from("beta.txt"),
+                    text: "the lazy cat".into(),
+                },
+            ],
+            Some(&MockTagger),
+        )
+        .unwrap();
+
+        // [pos="NN"] across both docs → dog + cat
+        let all = idx
+            .cql_kwic(
+                &CqlQuery {
+                    tokens: vec![pos("NN")],
+                },
+                1,
+                50,
+                0,
+                None,
+            )
+            .unwrap();
+        assert_eq!(all.total, 2);
+
+        // Filter to alpha.txt → only dog
+        let only_alpha = DocFilter {
+            path: Some("alpha".into()),
+            ..Default::default()
+        };
+        let page = idx
+            .cql_kwic(
+                &CqlQuery {
+                    tokens: vec![pos("NN")],
+                },
+                1,
+                50,
+                0,
+                Some(&only_alpha),
+            )
+            .unwrap();
+        assert_eq!(page.total, 1);
+        assert_eq!(page.hits[0].hit, "dog");
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/corpust-query/Cargo.toml
+++ b/crates/corpust-query/Cargo.toml
@@ -11,6 +11,7 @@ description = "Corpust: query layer over the index."
 corpust-core.workspace = true
 corpust-index.workspace = true
 anyhow.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 corpust-annotate.workspace = true

--- a/crates/corpust-query/src/lib.rs
+++ b/crates/corpust-query/src/lib.rs
@@ -5,10 +5,17 @@
 //! at that point the façade grows a real query-plan pipeline without changing
 //! callers' import paths.
 
-use anyhow::Result;
-use corpust_index::{CorpusIndex, DEFAULT_CONTEXT, DEFAULT_LIMIT, DocFilter, KwicPage, QueryLayer};
+use anyhow::{Result, anyhow, bail};
+use corpust_index::{
+    AttrConstraint, CorpusIndex, CqlQuery, DEFAULT_CONTEXT, DEFAULT_LIMIT, DocFilter, KwicPage,
+    Matcher, QueryLayer, TokenPattern,
+};
+use regex::RegexBuilder;
 
-pub use corpust_index::{DocFilter as Filter, QueryLayer as Layer};
+pub use corpust_index::{
+    AttrConstraint as CqlConstraint, CqlQuery as Query, DocFilter as Filter, Matcher as CqlMatcher,
+    QueryLayer as Layer, TokenPattern as CqlToken,
+};
 
 /// Parameters for a KWIC query.
 #[derive(Debug, Clone)]
@@ -64,14 +71,176 @@ impl<'a> KwicRequest<'a> {
 
 pub fn kwic(index: &CorpusIndex, request: KwicRequest<'_>) -> Result<KwicPage> {
     let filter = (!request.filter.is_empty()).then_some(&request.filter);
-    index.kwic_filtered(
-        request.term,
-        request.layer,
-        request.context,
-        request.limit,
-        request.offset,
-        filter,
-    )
+    if is_cql(request.term) {
+        let query = parse_cql(request.term)?;
+        index.cql_kwic(
+            &query,
+            request.context,
+            request.limit,
+            request.offset,
+            filter,
+        )
+    } else {
+        index.kwic_filtered(
+            request.term,
+            request.layer,
+            request.context,
+            request.limit,
+            request.offset,
+            filter,
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CQL — corpus query language
+// ---------------------------------------------------------------------------
+//
+// Grammar (phase 1):
+//   query  := token+
+//   token  := '[' constraint (ws constraint)* ']' | '"' value '"'
+//   constraint := attr '=' '"' value '"'
+//   attr   := word | lemma | pos   (aliases: hw→lemma, tag→pos)
+// A bare quoted token `"x"` is sugar for `[word="x"]`. Values are exact
+// when they contain only word characters, otherwise compiled as a
+// full-token-anchored regex (case-insensitive for word/lemma).
+
+/// True when `input` should be parsed as CQL rather than a bare term: it
+/// contains a `[` token, or starts with a quote. Bare terms keep the
+/// classic single-layer behaviour.
+pub fn is_cql(input: &str) -> bool {
+    let t = input.trim_start();
+    t.starts_with('[') || t.starts_with('"') || input.contains('[')
+}
+
+/// Parse a CQL string into a [`CqlQuery`]. Returns a descriptive error on
+/// malformed input (the UI surfaces it in place of results).
+pub fn parse_cql(input: &str) -> Result<CqlQuery> {
+    let chars: Vec<char> = input.chars().collect();
+    let mut i = 0;
+    let mut tokens = Vec::new();
+    skip_ws(&chars, &mut i);
+    while i < chars.len() {
+        match chars[i] {
+            '[' => tokens.push(parse_bracket_token(&chars, &mut i)?),
+            '"' => {
+                let value = parse_quoted(&chars, &mut i)?;
+                tokens.push(TokenPattern {
+                    constraints: vec![make_constraint(QueryLayer::Word, &value)?],
+                });
+            }
+            c => bail!("unexpected `{c}` — expected a `[…]` token or a quoted string"),
+        }
+        skip_ws(&chars, &mut i);
+    }
+    if tokens.is_empty() {
+        bail!("empty query");
+    }
+    Ok(CqlQuery { tokens })
+}
+
+fn skip_ws(chars: &[char], i: &mut usize) {
+    while *i < chars.len() && chars[*i].is_whitespace() {
+        *i += 1;
+    }
+}
+
+fn parse_bracket_token(chars: &[char], i: &mut usize) -> Result<TokenPattern> {
+    *i += 1; // consume '['
+    let mut constraints = Vec::new();
+    loop {
+        skip_ws(chars, i);
+        match chars.get(*i) {
+            None => bail!("unterminated `[` — missing `]`"),
+            Some(']') => {
+                *i += 1;
+                break;
+            }
+            Some(c) if c.is_alphabetic() => {
+                let attr = parse_ident(chars, i);
+                let layer = resolve_attr(&attr)?;
+                skip_ws(chars, i);
+                if chars.get(*i) != Some(&'=') {
+                    bail!("expected `=` after attribute `{attr}`");
+                }
+                *i += 1; // consume '='
+                skip_ws(chars, i);
+                if chars.get(*i) != Some(&'"') {
+                    bail!("expected a quoted value after `{attr}=`");
+                }
+                let value = parse_quoted(chars, i)?;
+                constraints.push(make_constraint(layer, &value)?);
+            }
+            Some(c) => bail!("unexpected `{c}` inside `[…]` — expected an attribute name or `]`"),
+        }
+    }
+    if constraints.is_empty() {
+        bail!("empty token `[]` — give it at least one attribute");
+    }
+    Ok(TokenPattern { constraints })
+}
+
+fn parse_ident(chars: &[char], i: &mut usize) -> String {
+    let start = *i;
+    while *i < chars.len() && (chars[*i].is_alphanumeric() || chars[*i] == '_') {
+        *i += 1;
+    }
+    chars[start..*i].iter().collect()
+}
+
+fn parse_quoted(chars: &[char], i: &mut usize) -> Result<String> {
+    *i += 1; // consume opening '"'
+    let start = *i;
+    while *i < chars.len() && chars[*i] != '"' {
+        *i += 1;
+    }
+    if chars.get(*i) != Some(&'"') {
+        bail!("unterminated quoted value");
+    }
+    let value: String = chars[start..*i].iter().collect();
+    *i += 1; // consume closing '"'
+    Ok(value)
+}
+
+fn resolve_attr(attr: &str) -> Result<QueryLayer> {
+    match attr {
+        "word" => Ok(QueryLayer::Word),
+        "lemma" | "hw" => Ok(QueryLayer::Lemma),
+        "pos" | "tag" => Ok(QueryLayer::Pos),
+        other => Err(anyhow!(
+            "unknown attribute `{other}` — use word, lemma (hw), or pos (tag)"
+        )),
+    }
+}
+
+/// Build a constraint, choosing exact vs regex matching. A value that is
+/// only word characters matches exactly (fast, single dict lookup);
+/// anything else compiles to a full-token-anchored regex. Word/lemma are
+/// case-insensitive (the index lowercases them); pos is case-sensitive.
+fn make_constraint(layer: QueryLayer, value: &str) -> Result<AttrConstraint> {
+    if value.is_empty() {
+        bail!("empty value");
+    }
+    let case_insensitive = !matches!(layer, QueryLayer::Pos);
+    let is_plain = value
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '-');
+    let matcher = if is_plain {
+        let text = if case_insensitive {
+            value.to_lowercase()
+        } else {
+            value.to_string()
+        };
+        Matcher::Exact(text)
+    } else {
+        let re = RegexBuilder::new(&format!("^(?:{value})$"))
+            .case_insensitive(case_insensitive)
+            .size_limit(1 << 20)
+            .build()
+            .map_err(|e| anyhow!("invalid regex `{value}`: {e}"))?;
+        Matcher::Regex(re)
+    };
+    Ok(AttrConstraint { layer, matcher })
 }
 
 #[cfg(test)]
@@ -135,5 +304,96 @@ mod tests {
         assert_eq!(p1.total, 2);
         assert_eq!(p1.hits.len(), 1);
         assert_ne!(p0.hits[0].hit_position, p1.hits[0].hit_position);
+    }
+
+    #[test]
+    fn is_cql_detects_bracket_and_quote_forms() {
+        assert!(is_cql("[pos=\"NN\"]"));
+        assert!(is_cql("\"bank\""));
+        assert!(is_cql("[word=\"a\"] [word=\"b\"]"));
+        assert!(!is_cql("bank"));
+        assert!(!is_cql("run.*")); // bare regex term stays a classic query
+    }
+
+    #[test]
+    fn parse_single_token_multi_attribute() {
+        let q = parse_cql("[word=\"bank\" pos=\"NN\"]").unwrap();
+        assert_eq!(q.tokens.len(), 1);
+        assert_eq!(q.tokens[0].constraints.len(), 2);
+        assert!(matches!(q.tokens[0].constraints[0].layer, QueryLayer::Word));
+        assert!(matches!(q.tokens[0].constraints[1].layer, QueryLayer::Pos));
+        // "bank" is plain → exact (and lowercased); "NN" is plain → exact.
+        assert!(matches!(&q.tokens[0].constraints[0].matcher, Matcher::Exact(t) if t == "bank"));
+    }
+
+    #[test]
+    fn parse_sequence_aliases_and_bare_quote() {
+        let q = parse_cql("\"the\" [tag=\"NN.*\"] [hw=\"be\"]").unwrap();
+        assert_eq!(q.tokens.len(), 3);
+        // bare quote → word
+        assert!(matches!(q.tokens[0].constraints[0].layer, QueryLayer::Word));
+        // tag → pos, value has a metachar → regex
+        assert!(matches!(q.tokens[1].constraints[0].layer, QueryLayer::Pos));
+        assert!(matches!(
+            q.tokens[1].constraints[0].matcher,
+            Matcher::Regex(_)
+        ));
+        // hw → lemma
+        assert!(matches!(
+            q.tokens[2].constraints[0].layer,
+            QueryLayer::Lemma
+        ));
+    }
+
+    #[test]
+    fn parse_errors_are_descriptive() {
+        assert!(
+            parse_cql("[word=\"a\"")
+                .unwrap_err()
+                .to_string()
+                .contains("]")
+        );
+        assert!(
+            parse_cql("[]")
+                .unwrap_err()
+                .to_string()
+                .contains("empty token")
+        );
+        assert!(
+            parse_cql("[foo=\"x\"]")
+                .unwrap_err()
+                .to_string()
+                .contains("unknown attribute")
+        );
+        assert!(parse_cql("[word=\"(\"]").is_err()); // invalid regex
+    }
+
+    #[test]
+    fn cql_kwic_equivalent_to_bare_term_on_word_layer() {
+        let (_tmp, idx) = tiny_index();
+        let bare = kwic(&idx, KwicRequest::new("the").context(2).limit(10)).unwrap();
+        let cql = kwic(
+            &idx,
+            KwicRequest::new("[word=\"the\"]").context(2).limit(10),
+        )
+        .unwrap();
+        assert_eq!(bare.total, cql.total);
+        assert_eq!(bare.hits.len(), cql.hits.len());
+        assert!(cql.hits.iter().all(|h| h.hit == "the"));
+    }
+
+    #[test]
+    fn cql_two_token_sequence_matches_adjacent_positions() {
+        let (_tmp, idx) = tiny_index();
+        // tiny_index body: "the quick brown fox jumps over the lazy dog"
+        let q = kwic(
+            &idx,
+            KwicRequest::new("[word=\"the\"] [word=\"lazy\"]")
+                .context(2)
+                .limit(10),
+        )
+        .unwrap();
+        assert_eq!(q.total, 1); // only "the lazy" (not "the quick")
+        assert_eq!(q.hits[0].hit, "the lazy");
     }
 }


### PR DESCRIPTION
Closes #50 — the **#1 LancsBox-parity gap**. Adds a real corpus query language: single-token attribute matching with regex, multi-attribute constraints, and multi-token sequences, wired into **KWIC, collocations (incl. distance), and term-distribution/over-time**. Auto-detected in the existing query box — a query containing `[` (or starting with a quote) is parsed as CQL; a bare term keeps the classic single-layer behaviour.

## Examples
- `[pos="N.*"]` — any noun
- `[word="bank" pos="NN"]` — "bank" as a noun
- `[pos="DT"] [pos="JJ"] [pos="NN"]` — determiner + adjective + noun
- `"the" [hw="be"]` — bare-quote shorthand + lemma alias

## Engine (`corpust-index/cql.rs`)
- AST (`CqlQuery`/`TokenPattern`/`AttrConstraint`/`Matcher`) + a shared `cql_scan` primitive that every surface consumes: resolve each constraint to terms (Exact → direct lookup; Regex → dict stream), merge positional postings by doc, intersect per-token position sets across a token's constraints, then sequence-match consecutive positions. Because `body`/`body_lemma`/`body_pos` share one tokenisation, position `p` is the same token on every layer — so multi-attribute matching is a position-set intersection.
- `doc_id` FAST-column subcorpus filtering + a matched-span ceiling (`truncated`) so broad patterns stay bounded.
- `cql_kwic` / `cql_collocate_counts` / `cql_collocate_by_distance` / `cql_term_distribution`; `window` generalised to `window_span` so a multi-token hit renders as one node span.

## Parser (`corpust-query`)
`parse_cql` + `is_cql`; attrs `word`/`lemma`/`pos` (aliases `hw`/`tag`), sequences, plain values matched exactly and metachar values compiled to full-token-anchored regex (word/lemma case-insensitive). The KWIC façade is now CQL-aware; descriptive parse errors propagate.

## Dispatch + frontend
Collocations / distance / distribution commands branch on a parsed CQL query; the CLI `kwic` auto-detects. The query box shows a `CQL` indicator and dims the (now-irrelevant) layer toggle; malformed-CQL errors surface in a banner instead of an empty table.

## Verification
- Rust: parser unit tests; index integration tests (pos, multi-attribute, sequence, regex, subcorpus filter); cargo `fmt` + `clippy -D warnings` clean; full `cargo test` green.
- Frontend: 76 vitest (façade/detection/indicator) + `tsc`/`vite build` green.
- **End-to-end via the CLI**: `[word="the"]`, `[word="the"] [word="lazy"]` (renders the span "the lazy"), `[word="qu.*"]`, and a deliberate parse error all behave correctly.
- Visually confirmed the CQL indicator + dimmed toggle.
- Caveat: not click-tested inside the packaged Tauri app, but the full stack is exercised by the CLI + integration tests and the IPC layer is unchanged in shape.

Follow-ups filed: #55 (syntax-highlighting query editor), #56 (CQL phase 2: quantifiers / structural scope).

closes #50