### PR TITLE
Smart CQL query editor — highlighting, completion, squiggles

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,6 +8,13 @@
       "name": "corpust-app",
       "version": "0.1.0",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.20.3",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/lint": "^6.9.6",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.43.0",
+        "@lezer/highlight": "^1.2.3",
         "@radix-ui/react-dialog": "^1.1.11",
         "@radix-ui/react-dropdown-menu": "^2.1.11",
         "@radix-ui/react-label": "^2.1.4",
@@ -418,6 +425,76 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
+      "integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
+      "integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1107,6 +1184,36 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -3510,6 +3617,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -4721,6 +4834,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5137,6 +5256,12 @@
           "optional": false
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,13 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.3",
+    "@codemirror/commands": "^6.10.3",
+    "@codemirror/language": "^6.12.3",
+    "@codemirror/lint": "^6.9.6",
+    "@codemirror/state": "^6.6.0",
+    "@codemirror/view": "^6.43.0",
+    "@lezer/highlight": "^1.2.3",
     "@radix-ui/react-dialog": "^1.1.11",
     "@radix-ui/react-dropdown-menu": "^2.1.11",
     "@radix-ui/react-label": "^2.1.4",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -305,6 +305,15 @@ export function App() {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const meta = e.metaKey || e.ctrlKey;
+      // Bare-key shortcuts (Escape, j/k nav) must not fire while typing in
+      // the query editor or any text field.
+      const t = e.target as HTMLElement | null;
+      const editable =
+        !!t &&
+        (t.tagName === "INPUT" ||
+          t.tagName === "TEXTAREA" ||
+          t.isContentEditable ||
+          !!t.closest(".cm-editor"));
       if (meta && e.key.toLowerCase() === "k") {
         e.preventDefault();
         setPaletteOpen(true);
@@ -323,9 +332,9 @@ export function App() {
       } else if (meta && e.key.toLowerCase() === "e") {
         e.preventDefault();
         exportConcordance("csv");
-      } else if (e.key === "Escape") {
+      } else if (e.key === "Escape" && !editable) {
         setSelected(null);
-      } else if ((e.key === "j" || e.key === "k") && result && !paletteOpen && !buildOpen) {
+      } else if ((e.key === "j" || e.key === "k") && !editable && result && !paletteOpen && !buildOpen) {
         const hits = result.hits;
         if (!hits.length) return;
         const idx = selected

--- a/app/src/components/query/CqlInput.tsx
+++ b/app/src/components/query/CqlInput.tsx
@@ -1,0 +1,198 @@
+// A single-line CodeMirror 6 editor for the query box: CQL syntax
+// highlighting, bracket matching/autoclose, attribute/POS completion, and
+// inline error squiggles. Honors the same contract as the plain input it
+// replaces — value / onChange / onRun (Enter) / disabled / placeholder —
+// and accepts bare terms unchanged. Colors come from app CSS variables
+// (see .cm-cql-* in index.css) so it follows any future theme.
+
+import {
+  type CompletionContext,
+  type CompletionResult,
+  autocompletion,
+  closeBrackets,
+  closeBracketsKeymap,
+  completionKeymap,
+} from "@codemirror/autocomplete";
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { bracketMatching } from "@codemirror/language";
+import { linter } from "@codemirror/lint";
+import { Compartment, EditorState, RangeSetBuilder } from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+  keymap,
+  placeholder as cmPlaceholder,
+} from "@codemirror/view";
+import { useEffect, useRef } from "react";
+import { ATTRS, POS_TAGS, completionAt, tokenizeCql, validateCql } from "@/lib/cqlLang";
+
+export interface CqlInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onRun: () => void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+}
+
+/** Decoration plugin: re-mark CQL tokens on every doc change. */
+const cqlHighlight = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    constructor(view: EditorView) {
+      this.decorations = buildDecorations(view);
+    }
+    update(u: ViewUpdate) {
+      if (u.docChanged || u.viewportChanged) this.decorations = buildDecorations(u.view);
+    }
+  },
+  { decorations: (v) => v.decorations },
+);
+
+function buildDecorations(view: EditorView): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  for (const tok of tokenizeCql(view.state.doc.toString())) {
+    builder.add(tok.from, tok.to, Decoration.mark({ class: `cm-cql-${tok.kind}` }));
+  }
+  return builder.finish();
+}
+
+const cqlLinter = linter((view) => {
+  const d = validateCql(view.state.doc.toString());
+  if (!d) return [];
+  return [{ from: d.from, to: Math.max(d.to, d.from + 1), severity: "error" as const, message: d.message }];
+});
+
+function cqlCompletion(ctx: CompletionContext): CompletionResult | null {
+  const spot = completionAt(ctx.state.doc.toString(), ctx.pos);
+  if (spot.kind === "attr") {
+    return {
+      from: spot.from,
+      options: ATTRS.map((label) => ({ label, type: "property" })),
+      validFor: /^[A-Za-z]*$/,
+    };
+  }
+  if (spot.kind === "posValue") {
+    return {
+      from: spot.from,
+      options: POS_TAGS.map((label) => ({ label, type: "constant" })),
+      validFor: /^[A-Za-z$]*$/,
+    };
+  }
+  return null;
+}
+
+/** Keep the editor to one line: cancel any transaction that introduces a
+ *  newline (e.g. paste of multi-line text collapses to nothing extra). */
+const singleLine = EditorState.transactionFilter.of((tr) => (tr.newDoc.lines > 1 ? [] : tr));
+
+/** Editor chrome matched to `.cx-input` (34px, inset bg, accent focus). */
+const theme = EditorView.theme({
+  "&": {
+    flex: "1",
+    minWidth: "0",
+    height: "34px",
+    background: "var(--bg-inset)",
+    border: "1px solid var(--border)",
+    borderRadius: "5px",
+    color: "var(--fg)",
+    fontSize: "13px",
+  },
+  "&.cm-focused": {
+    outline: "none",
+    borderColor: "var(--accent)",
+    boxShadow: "0 0 0 2px color-mix(in oklch, var(--accent) 40%, transparent)",
+  },
+  ".cm-scroller": {
+    fontFamily: "var(--font-mono)",
+    lineHeight: "32px",
+    overflowX: "auto",
+    overflowY: "hidden",
+  },
+  ".cm-content": { padding: "0 12px 0 32px", caretColor: "var(--fg)" },
+  ".cm-line": { padding: "0" },
+  ".cm-placeholder": { color: "var(--fg-subtle)" },
+});
+
+export function CqlInput({ value, onChange, onRun, disabled, placeholder, className }: CqlInputProps) {
+  const host = useRef<HTMLDivElement | null>(null);
+  const view = useRef<EditorView | null>(null);
+  // Latest callbacks, so the once-built keymap/listener always call current props.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const onRunRef = useRef(onRun);
+  onRunRef.current = onRun;
+  const placeholderComp = useRef(new Compartment());
+  const editableComp = useRef(new Compartment());
+
+  // Build the editor once.
+  useEffect(() => {
+    if (!host.current) return;
+    const state = EditorState.create({
+      doc: value,
+      extensions: [
+        keymap.of([
+          { key: "Enter", run: () => (onRunRef.current(), true), preventDefault: true },
+          { key: "Mod-Enter", run: () => (onRunRef.current(), true), preventDefault: true },
+          ...closeBracketsKeymap,
+          ...completionKeymap,
+          ...historyKeymap,
+          ...defaultKeymap,
+        ]),
+        history(),
+        closeBrackets(),
+        bracketMatching(),
+        autocompletion({ override: [cqlCompletion] }),
+        cqlHighlight,
+        cqlLinter,
+        singleLine,
+        theme,
+        placeholderComp.current.of(cmPlaceholder(placeholder ?? "")),
+        editableComp.current.of([
+          EditorView.editable.of(!disabled),
+          EditorState.readOnly.of(!!disabled),
+        ]),
+        EditorView.updateListener.of((u) => {
+          if (u.docChanged) onChangeRef.current(u.state.doc.toString());
+        }),
+      ],
+    });
+    const v = new EditorView({ state, parent: host.current });
+    view.current = v;
+    return () => {
+      v.destroy();
+      view.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync external value changes (e.g. recent-query click) without loops.
+  useEffect(() => {
+    const v = view.current;
+    if (!v) return;
+    const cur = v.state.doc.toString();
+    if (cur !== value) {
+      v.dispatch({ changes: { from: 0, to: cur.length, insert: value } });
+    }
+  }, [value]);
+
+  useEffect(() => {
+    view.current?.dispatch({
+      effects: placeholderComp.current.reconfigure(cmPlaceholder(placeholder ?? "")),
+    });
+  }, [placeholder]);
+
+  useEffect(() => {
+    view.current?.dispatch({
+      effects: editableComp.current.reconfigure([
+        EditorView.editable.of(!disabled),
+        EditorState.readOnly.of(!!disabled),
+      ]),
+    });
+  }, [disabled]);
+
+  return <div ref={host} className={className} />;
+}

--- a/app/src/components/query/QueryBar.tsx
+++ b/app/src/components/query/QueryBar.tsx
@@ -3,6 +3,7 @@ import { type FormEvent, useEffect, useState } from "react";
 import { isCql } from "@/lib/cql";
 import { clearDimension, filterChips, normalizeFilter } from "@/lib/filter";
 import type { DocFilter, QueryLayer } from "@/types";
+import { CqlInput } from "./CqlInput";
 
 const LAYERS: { value: QueryLayer; label: string; hint: string }[] = [
   { value: "word", label: "word", hint: "surface form · case-insensitive" },
@@ -77,19 +78,21 @@ export function QueryBar({
         <span className="cx-input-icon">
           <Search size={14} />
         </span>
-        <input
-          className="cx-input cx-input-mono"
+        <CqlInput
+          className="cx-cql-host"
           value={term}
-          onChange={(e) => onTerm(e.target.value)}
+          onChange={onTerm}
+          onRun={() => {
+            if (term.trim()) onRun();
+          }}
+          disabled={disabled}
           placeholder={
             layer === "pos"
-              ? "POS tag (e.g. NN, VBD, IN)…"
+              ? 'POS tag, or [pos="NN"]…'
               : layer === "lemma"
-                ? "lemma (e.g. go, be, run)…"
-                : "term or regex…"
+                ? 'lemma, or [hw="be"]…'
+                : 'term, regex, or [word="x" pos="NN"]…'
           }
-          disabled={disabled}
-          spellCheck={false}
         />
         <div className="cx-input-suffix">
           {term && <span>{cql ? "CQL" : layer === "pos" ? "exact" : "regex ok"}</span>}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -353,6 +353,22 @@
   min-width: 0; width: 100%;
 }
 .cx-input-mono { font-family: var(--font-mono); }
+
+/* CQL editor (CodeMirror) — host fills the input wrap; chrome is themed in
+   CqlInput.tsx, token colours + lint underline here (CSS-variable driven so
+   they follow any future theme). */
+.cx-cql-host { flex: 1; min-width: 0; display: flex; }
+.cx-cql-host .cm-editor { width: 100%; }
+.cm-cql-bracket { color: var(--fg-subtle); }
+.cm-cql-attr { color: var(--layer-lemma); }
+.cm-cql-operator { color: var(--fg-subtle); }
+.cm-cql-string { color: var(--success); }
+.cm-cql-regex { color: var(--warn); }
+.cm-cql-invalid { color: var(--danger); }
+.cm-lintRange-error {
+  text-decoration: underline wavy color-mix(in oklch, var(--danger) 80%, transparent);
+  text-underline-offset: 3px;
+}
 .cx-input::placeholder { color: var(--fg-subtle); }
 .cx-input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px color-mix(in oklch, var(--accent) 40%, transparent); }
 .cx-input-icon {

--- a/app/src/lib/cqlLang.test.ts
+++ b/app/src/lib/cqlLang.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { completionAt, tokenizeCql, validateCql } from "./cqlLang";
+
+describe("tokenizeCql", () => {
+  it("returns nothing for a bare (non-CQL) term", () => {
+    expect(tokenizeCql("linguistic")).toEqual([]);
+    expect(tokenizeCql("run.*")).toEqual([]);
+  });
+
+  it("classifies brackets, attributes, operators, and values", () => {
+    const kinds = tokenizeCql('[word="bank" pos="N.*"]').map((t) => t.kind);
+    expect(kinds).toEqual(["bracket", "attr", "operator", "string", "attr", "operator", "regex", "bracket"]);
+  });
+
+  it("marks unknown identifiers and stray chars invalid", () => {
+    const toks = tokenizeCql('[foo="x"]');
+    expect(toks.find((t) => t.kind === "attr")).toBeUndefined();
+    expect(toks.some((t) => t.kind === "invalid")).toBe(true);
+  });
+});
+
+describe("validateCql", () => {
+  it("accepts valid queries (and bare terms)", () => {
+    expect(validateCql("linguistic")).toBeNull();
+    expect(validateCql('[word="bank" pos="NN"]')).toBeNull();
+    expect(validateCql('"the" [pos="N.*"]')).toBeNull();
+  });
+
+  it("flags each malformed shape with a span + message", () => {
+    expect(validateCql('[word="a"')?.message).toMatch(/missing `\]`/);
+    expect(validateCql("[]")?.message).toMatch(/empty token/);
+    expect(validateCql('[foo="x"]')?.message).toMatch(/unknown attribute/);
+    expect(validateCql('[word"x"]')?.message).toMatch(/expected `=`/);
+    expect(validateCql('[word=x]')?.message).toMatch(/expected a quoted value/);
+    expect(validateCql('[word="("]')?.message).toMatch(/invalid regex/);
+    const d = validateCql("[]");
+    expect(d && d.to > d.from).toBe(true);
+  });
+});
+
+describe("completionAt", () => {
+  it("offers attribute completion inside an empty bracket", () => {
+    const q = "[";
+    expect(completionAt(q, q.length)).toEqual({ kind: "attr", from: 1 });
+  });
+
+  it("offers POS-value completion inside a pos/tag value", () => {
+    const q = '[pos="N';
+    expect(completionAt(q, q.length).kind).toBe("posValue");
+    const q2 = '[tag="';
+    expect(completionAt(q2, q2.length).kind).toBe("posValue");
+  });
+
+  it("offers nothing inside a word value or outside brackets", () => {
+    const q = '[word="ba';
+    expect(completionAt(q, q.length).kind).toBe("none");
+    expect(completionAt("bank", 4).kind).toBe("none");
+    expect(completionAt('[a="x"] ', 8).kind).toBe("none");
+  });
+});

--- a/app/src/lib/cqlLang.ts
+++ b/app/src/lib/cqlLang.ts
@@ -1,0 +1,210 @@
+// CQL language support for the query editor: a tokenizer (syntax
+// highlighting), a validator (inline error squiggles), and completion
+// context. Framework-agnostic and unit-tested; the CodeMirror glue lives
+// in CqlInput.tsx. Mirrors the Rust grammar/errors in
+// crates/corpust-query/src/lib.rs — keep the two in sync.
+
+import { isCql } from "./cql";
+
+/** Known attributes and their canonical layer (aliases included). */
+export const ATTRS = ["word", "lemma", "pos", "hw", "tag"] as const;
+
+/** Common Penn-Treebank-ish POS tags, for value completion on pos/tag.
+ *  (Corpus-derived tags are a later enhancement.) */
+export const POS_TAGS = [
+  "NN", "NNS", "NNP", "NNPS", "VB", "VBD", "VBG", "VBN", "VBP", "VBZ",
+  "JJ", "JJR", "JJS", "RB", "RBR", "RBS", "DT", "IN", "CC", "CD",
+  "PRP", "PRP$", "WP", "WDT", "MD", "TO", "UH", "FW",
+] as const;
+
+export type TokenKind = "bracket" | "attr" | "operator" | "string" | "regex" | "invalid";
+
+export interface CqlToken {
+  from: number;
+  to: number;
+  kind: TokenKind;
+}
+
+export interface CqlDiagnostic {
+  from: number;
+  to: number;
+  message: string;
+}
+
+const ATTR_SET: ReadonlySet<string> = new Set(ATTRS);
+const REGEX_META = /[.*+?^${}()|[\]\\]/;
+
+function isIdentChar(c: string): boolean {
+  return /[A-Za-z0-9_]/.test(c);
+}
+
+/** Classify a quoted value as a regex (has metachars) or a plain string. */
+function valueKind(value: string): TokenKind {
+  return REGEX_META.test(value) ? "regex" : "string";
+}
+
+/** Tokenize for highlighting. Returns marks in document order. Bare
+ *  (non-CQL) input yields no tokens so it renders as plain text. */
+export function tokenizeCql(text: string): CqlToken[] {
+  if (!isCql(text)) return [];
+  const tokens: CqlToken[] = [];
+  let i = 0;
+  let depth = 0;
+  while (i < text.length) {
+    const c = text[i];
+    if (/\s/.test(c)) {
+      i++;
+      continue;
+    }
+    if (c === "[") {
+      tokens.push({ from: i, to: i + 1, kind: "bracket" });
+      depth++;
+      i++;
+    } else if (c === "]") {
+      tokens.push({ from: i, to: i + 1, kind: "bracket" });
+      depth = Math.max(0, depth - 1);
+      i++;
+    } else if (c === "=") {
+      tokens.push({ from: i, to: i + 1, kind: depth > 0 ? "operator" : "invalid" });
+      i++;
+    } else if (c === '"') {
+      const start = i;
+      i++;
+      while (i < text.length && text[i] !== '"') i++;
+      const closed = i < text.length;
+      const value = text.slice(start + 1, i);
+      if (closed) i++; // consume closing quote
+      tokens.push({ from: start, to: i, kind: closed ? valueKind(value) : "invalid" });
+    } else if (isIdentChar(c)) {
+      const start = i;
+      while (i < text.length && isIdentChar(text[i])) i++;
+      const ident = text.slice(start, i);
+      const kind: TokenKind = depth > 0 && ATTR_SET.has(ident) ? "attr" : "invalid";
+      tokens.push({ from: start, to: i, kind });
+    } else {
+      tokens.push({ from: i, to: i + 1, kind: "invalid" });
+      i++;
+    }
+  }
+  return tokens;
+}
+
+/** Validate a CQL string, returning the first error (or `null` when valid
+ *  / not a CQL query). Mirrors `parse_cql` in corpust-query. */
+export function validateCql(text: string): CqlDiagnostic | null {
+  if (!isCql(text)) return null;
+
+  let i = 0;
+  const n = text.length;
+  const skipWs = () => {
+    while (i < n && /\s/.test(text[i])) i++;
+  };
+  let tokenCount = 0;
+
+  skipWs();
+  while (i < n) {
+    const c = text[i];
+    if (c === "[") {
+      const err = parseBracket();
+      if (err) return err;
+      tokenCount++;
+    } else if (c === '"') {
+      const err = parseQuoted();
+      if (err) return err;
+      tokenCount++;
+    } else {
+      return { from: i, to: i + 1, message: `unexpected \`${c}\` — expected a \`[…]\` token or a quoted string` };
+    }
+    skipWs();
+  }
+  if (tokenCount === 0) return { from: 0, to: n, message: "empty query" };
+  return null;
+
+  // --- helpers (close over i/text) ---
+  function parseQuoted(): CqlDiagnostic | null {
+    const start = i;
+    i++; // opening quote
+    while (i < n && text[i] !== '"') i++;
+    if (i >= n) return { from: start, to: n, message: "unterminated quoted value" };
+    i++; // closing quote
+    return checkRegex(text.slice(start + 1, i - 1), start, i);
+  }
+
+  function parseBracket(): CqlDiagnostic | null {
+    const bracketStart = i;
+    i++; // '['
+    let constraints = 0;
+    for (;;) {
+      skipWs();
+      if (i >= n) return { from: bracketStart, to: n, message: "unterminated `[` — missing `]`" };
+      const c = text[i];
+      if (c === "]") {
+        i++;
+        if (constraints === 0) {
+          return { from: bracketStart, to: i, message: "empty token `[]` — give it at least one attribute" };
+        }
+        return null;
+      }
+      if (/[A-Za-z]/.test(c)) {
+        const attrFrom = i;
+        while (i < n && isIdentChar(text[i])) i++;
+        const attr = text.slice(attrFrom, i);
+        if (!ATTR_SET.has(attr)) {
+          return { from: attrFrom, to: i, message: `unknown attribute \`${attr}\` — use word, lemma (hw), or pos (tag)` };
+        }
+        skipWs();
+        if (text[i] !== "=") return { from: i, to: i + 1, message: `expected \`=\` after attribute \`${attr}\`` };
+        i++; // '='
+        skipWs();
+        if (text[i] !== '"') return { from: i, to: i + 1, message: `expected a quoted value after \`${attr}=\`` };
+        const err = parseQuoted();
+        if (err) return err;
+        constraints++;
+      } else {
+        return { from: i, to: i + 1, message: `unexpected \`${c}\` inside \`[…]\` — expected an attribute name or \`]\`` };
+      }
+    }
+  }
+
+  function checkRegex(value: string, from: number, to: number): CqlDiagnostic | null {
+    if (value.length === 0) return { from, to, message: "empty value" };
+    if (!REGEX_META.test(value)) return null; // plain value, exact match
+    try {
+      // Validate the same shape the backend compiles.
+      void new RegExp(`^(?:${value})$`);
+      return null;
+    } catch (e) {
+      return { from, to, message: `invalid regex \`${value}\`: ${(e as Error).message}` };
+    }
+  }
+}
+
+export type CompletionSpot =
+  | { kind: "attr"; from: number }
+  | { kind: "posValue"; from: number }
+  | { kind: "none" };
+
+/** What completion makes sense at `pos`: an attribute name inside a
+ *  bracket, or a POS-tag value inside a `pos="…"` / `tag="…"`. */
+export function completionAt(text: string, pos: number): CompletionSpot {
+  const before = text.slice(0, pos);
+  const lastOpen = before.lastIndexOf("[");
+  const lastClose = before.lastIndexOf("]");
+  if (lastOpen < 0 || lastOpen < lastClose) return { kind: "none" };
+  const inBracket = before.slice(lastOpen);
+  // An odd number of quotes since `[` means we're inside a value.
+  const quotes = (inBracket.match(/"/g) ?? []).length;
+  if (quotes % 2 === 1) {
+    // Inside a value — offer POS tags only for pos/tag attributes.
+    const attrMatch = inBracket.match(/([A-Za-z]+)\s*=\s*"[^"]*$/);
+    const attr = attrMatch?.[1];
+    if (attr === "pos" || attr === "tag") {
+      const valStart = before.lastIndexOf('"') + 1;
+      return { kind: "posValue", from: valStart };
+    }
+    return { kind: "none" };
+  }
+  // Outside a value → attribute-name position. Complete the current word.
+  const wordMatch = before.match(/[A-Za-z]*$/);
+  return { kind: "attr", from: pos - (wordMatch?.[0].length ?? 0) };
+}


### PR DESCRIPTION
Closes #55. Replaces the plain query `<input>` with a **CodeMirror 6 single-line editor**, so complex CQL queries (`[word="bank" pos="N.*"] [pos="IN"]`) are pleasant and discoverable to write — companion to the CQL engine (#50).

## Features
- **Syntax highlighting** — brackets / attributes / operators / strings / regex, coloured from app CSS variables (so it follows any future theme system, #58).
- **Bracket matching + autoclose** (`[ ]`, quotes).
- **Completion** — attribute names (word/lemma/pos/hw/tag) inside brackets; a static Penn POS-tag list inside `pos="…"` / `tag="…"` values.
- **Inline error squiggles** — a client-side validator mirroring the Rust `parse_cql` grammar + error wording (the backend error banner remains the authoritative surface).
- **Bare terms unaffected** — only CQL (detected by `isCql`) is highlighted; plain terms render as plain text and degrade gracefully.

## Implementation
- `lib/cqlLang.ts` — framework-agnostic `tokenizeCql` / `validateCql` / `completionAt` (+ `ATTRS`, `POS_TAGS`), unit-tested.
- `components/query/CqlInput.tsx` — CM6 wrapper honouring the old input contract (value/onChange/onRun/disabled/placeholder); single-line via a newline-rejecting transaction filter; Enter / Mod-Enter → run; value/placeholder/disabled synced via compartments.
- QueryBar swaps the input for `<CqlInput>`; editor chrome themed to match `.cx-input`.
- **App keydown guard**: the bare-key shortcuts (Escape, `j`/`k` hit-nav) are now gated against editable targets — fixes the latent bug where typing `j`/`k` in the query box moved the concordance selection.

## Cost
Adds `@codemirror/*` + `@lezer/highlight` (~+110 kB gzip on the JS bundle). Acceptable for a desktop app; could code-split later if desired.

## Verification
- vitest: `cqlLang` tokenizer / lint-diagnostic / completion tests; full suite **84 green**; `tsc` + `vite build` green.
- Visual: confirmed highlighting on a valid multi-token query, the unknown-attribute error state (red token), and bare-term passthrough.
- Caveat: CodeMirror mounts fine in jsdom for the component tests, but the editor wasn't click-tested inside the packaged Tauri app; behaviour is identical to the browser preview where it was screenshotted.

Follow-ups filed: #58 (theming system — the editor already reads CSS-var colours), #59 (CI performance benchmarks). Corpus-derived POS completion values deferred (static Penn list for now).

closes #55