### PR TITLE
Polish the CQL editor: dark IDE popup + inline errors

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -24,6 +24,7 @@ import { CommandPalette, type CommandDef } from "@/components/overlays/CommandPa
 import { BuildDialog } from "@/components/overlays/BuildDialog";
 import { CORPORA, RECENT_QUERIES, pickHits } from "@/data";
 import { isCql } from "@/lib/cql";
+import { validateCql } from "@/lib/cqlLang";
 import { concordanceCsv, concordanceJson, saveText, slug } from "@/lib/export";
 import { normalizeFilter } from "@/lib/filter";
 import { makeDensity } from "@/lib/utils";
@@ -138,6 +139,15 @@ export function App() {
     (corpus: CorpusMeta | null, q: string, lyr: QueryLayer, offset: number) => {
       if (!corpus || !q.trim()) {
         setResult(null);
+        setQueryError(null);
+        setLoading(false);
+        return;
+      }
+      // A client-invalid CQL query is already flagged inline by the editor;
+      // don't round-trip it to the backend (typing autocloses quotes, which
+      // momentarily makes `[pos=""]` and would surface a transient "empty
+      // value" error). Keep the last results on screen until it parses.
+      if (isCql(q) && validateCql(q)) {
         setQueryError(null);
         setLoading(false);
         return;
@@ -450,13 +460,8 @@ export function App() {
           filter={filter}
           onFilterChange={setFilter}
           filterable={!!activeCorpus && hasLiveData(activeCorpus.id)}
+          error={queryError}
         />
-        {queryError && (
-          <div className="cx-query-error">
-            <span className="label">query error</span>
-            <span>{queryError}</span>
-          </div>
-        )}
         <ViewTabs view={subview} onView={setSubview} result={result} />
         <div className="cx-results-wrap">
           {subview === "kwic" && (

--- a/app/src/components/query/CqlInput.tsx
+++ b/app/src/components/query/CqlInput.tsx
@@ -15,8 +15,8 @@ import {
 } from "@codemirror/autocomplete";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { bracketMatching } from "@codemirror/language";
-import { linter } from "@codemirror/lint";
-import { Compartment, EditorState, RangeSetBuilder } from "@codemirror/state";
+import { forceLinting, linter } from "@codemirror/lint";
+import { Compartment, EditorState, RangeSetBuilder, StateEffect, StateField } from "@codemirror/state";
 import {
   Decoration,
   type DecorationSet,
@@ -42,7 +42,22 @@ export interface CqlInputProps {
   disabled?: boolean;
   placeholder?: string;
   className?: string;
+  /** A backend error for the current query (e.g. an exec failure the
+   *  client validator can't catch). Shown inline as a whole-query
+   *  diagnostic — no separate banner. */
+  error?: string | null;
 }
+
+// Carries the backend error into the editor so it shows as an inline
+// diagnostic alongside client-side parse errors.
+const setExternalError = StateEffect.define<string | null>();
+const externalErrorField = StateField.define<string | null>({
+  create: () => null,
+  update(value, tr) {
+    for (const e of tr.effects) if (e.is(setExternalError)) return e.value;
+    return value;
+  },
+});
 
 /** Decoration plugin: re-mark CQL tokens on every doc change. */
 const cqlHighlight = ViewPlugin.fromClass(
@@ -67,9 +82,18 @@ function buildDecorations(view: EditorView): DecorationSet {
 }
 
 const cqlLinter = linter((view) => {
-  const d = validateCql(view.state.doc.toString());
-  if (!d) return [];
-  return [{ from: d.from, to: Math.max(d.to, d.from + 1), severity: "error" as const, message: d.message }];
+  const text = view.state.doc.toString();
+  // Precise client-side parse error wins (specific span); otherwise fall
+  // back to a backend error spanning the whole query.
+  const d = validateCql(text);
+  if (d) {
+    return [{ from: d.from, to: Math.max(d.to, d.from + 1), severity: "error" as const, message: d.message }];
+  }
+  const ext = view.state.field(externalErrorField, false);
+  if (ext) {
+    return [{ from: 0, to: Math.max(text.length, 1), severity: "error" as const, message: ext }];
+  }
+  return [];
 });
 
 function cqlCompletion(ctx: CompletionContext): CompletionResult | null {
@@ -137,7 +161,7 @@ const theme = EditorView.theme({
   },
 }, { dark: true }); // tell CodeMirror this is a dark theme → dark popups/selection
 
-export function CqlInput({ value, onChange, onRun, disabled, placeholder, className }: CqlInputProps) {
+export function CqlInput({ value, onChange, onRun, disabled, placeholder, className, error }: CqlInputProps) {
   const host = useRef<HTMLDivElement | null>(null);
   const view = useRef<EditorView | null>(null);
   // Latest callbacks, so the once-built keymap/listener always call current props.
@@ -167,6 +191,7 @@ export function CqlInput({ value, onChange, onRun, disabled, placeholder, classN
         bracketMatching(),
         autocompletion({ override: [cqlCompletion] }),
         cqlHighlight,
+        externalErrorField,
         cqlLinter,
         singleLine,
         theme,
@@ -213,6 +238,15 @@ export function CqlInput({ value, onChange, onRun, disabled, placeholder, classN
       ]),
     });
   }, [disabled]);
+
+  // Push the backend error into the editor and re-lint so it surfaces
+  // inline (squiggle + hover) instead of in a separate banner.
+  useEffect(() => {
+    const v = view.current;
+    if (!v) return;
+    v.dispatch({ effects: setExternalError.of(error ?? null) });
+    forceLinting(v);
+  }, [error]);
 
   return <div ref={host} className={className} />;
 }

--- a/app/src/components/query/CqlInput.tsx
+++ b/app/src/components/query/CqlInput.tsx
@@ -27,7 +27,13 @@ import {
   placeholder as cmPlaceholder,
 } from "@codemirror/view";
 import { useEffect, useRef } from "react";
-import { ATTRS, POS_TAGS, completionAt, tokenizeCql, validateCql } from "@/lib/cqlLang";
+import {
+  ATTR_COMPLETIONS,
+  POS_COMPLETIONS,
+  completionAt,
+  tokenizeCql,
+  validateCql,
+} from "@/lib/cqlLang";
 
 export interface CqlInputProps {
   value: string;
@@ -71,14 +77,24 @@ function cqlCompletion(ctx: CompletionContext): CompletionResult | null {
   if (spot.kind === "attr") {
     return {
       from: spot.from,
-      options: ATTRS.map((label) => ({ label, type: "property" })),
+      options: ATTR_COMPLETIONS.map((c) => ({
+        label: c.label,
+        detail: c.detail,
+        info: c.info,
+        type: "property",
+      })),
       validFor: /^[A-Za-z]*$/,
     };
   }
   if (spot.kind === "posValue") {
     return {
       from: spot.from,
-      options: POS_TAGS.map((label) => ({ label, type: "constant" })),
+      options: POS_COMPLETIONS.map((c) => ({
+        label: c.label,
+        detail: c.detail,
+        info: c.info,
+        type: "enum",
+      })),
       validFor: /^[A-Za-z$]*$/,
     };
   }
@@ -115,7 +131,11 @@ const theme = EditorView.theme({
   ".cm-content": { padding: "0 12px 0 32px", caretColor: "var(--fg)" },
   ".cm-line": { padding: "0" },
   ".cm-placeholder": { color: "var(--fg-subtle)" },
-});
+  // Selection in the editor itself (not the popup).
+  "&.cm-focused .cm-selectionBackground, ::selection": {
+    background: "color-mix(in oklch, var(--accent) 30%, transparent)",
+  },
+}, { dark: true }); // tell CodeMirror this is a dark theme → dark popups/selection
 
 export function CqlInput({ value, onChange, onRun, disabled, placeholder, className }: CqlInputProps) {
   const host = useRef<HTMLDivElement | null>(null);

--- a/app/src/components/query/QueryBar.tsx
+++ b/app/src/components/query/QueryBar.tsx
@@ -1,6 +1,7 @@
 import { Plus, Search, X } from "lucide-react";
 import { type FormEvent, useEffect, useState } from "react";
 import { isCql } from "@/lib/cql";
+import { validateCql } from "@/lib/cqlLang";
 import { clearDimension, filterChips, normalizeFilter } from "@/lib/filter";
 import type { DocFilter, QueryLayer } from "@/types";
 import { CqlInput } from "./CqlInput";
@@ -26,6 +27,8 @@ export interface QueryBarProps {
   /** Whether the active corpus supports filtering (real, backend-backed).
    *  Fixtures / preview have no queryable metadata, so the control hides. */
   filterable: boolean;
+  /** Backend error for the current query, surfaced inline in the editor. */
+  error?: string | null;
 }
 
 export function QueryBar({
@@ -40,6 +43,7 @@ export function QueryBar({
   filter,
   onFilterChange,
   filterable,
+  error,
 }: QueryBarProps) {
   const submit = (e: FormEvent) => {
     e.preventDefault();
@@ -50,6 +54,11 @@ export function QueryBar({
   // A CQL query spans layers itself, so the word/lemma/pos toggle no longer
   // applies — dim it and flag the input as CQL.
   const cql = isCql(term);
+  // Error state for the suffix marker: a client-side parse error (precise)
+  // or a backend error. The full message shows on hover + as an inline
+  // squiggle in the editor.
+  const parseErr = cql && term.trim() ? validateCql(term) : null;
+  const errMsg = parseErr?.message ?? error ?? null;
 
   return (
     <form onSubmit={submit} className="cx-querybar">
@@ -86,6 +95,7 @@ export function QueryBar({
             if (term.trim()) onRun();
           }}
           disabled={disabled}
+          error={error}
           placeholder={
             layer === "pos"
               ? 'POS tag, or [pos="NN"]…'
@@ -95,7 +105,14 @@ export function QueryBar({
           }
         />
         <div className="cx-input-suffix">
-          {term && <span>{cql ? "CQL" : layer === "pos" ? "exact" : "regex ok"}</span>}
+          {term &&
+            (errMsg ? (
+              <span className="cx-suffix-error" title={errMsg}>
+                error
+              </span>
+            ) : (
+              <span>{cql ? "CQL" : layer === "pos" ? "exact" : "regex ok"}</span>
+            ))}
         </div>
       </div>
 

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -369,6 +369,106 @@
   text-decoration: underline wavy color-mix(in oklch, var(--danger) 80%, transparent);
   text-underline-offset: 3px;
 }
+/* Matched/!matched brackets — subtle accent, not the default grey block. */
+.cm-matchingBracket {
+  background: color-mix(in oklch, var(--accent) 20%, transparent);
+  color: var(--fg) !important;
+  outline: none;
+}
+.cm-nonmatchingBracket { color: var(--danger) !important; background: none; }
+
+/* CodeMirror popups (completion + lint) rendered in a portal — a polished,
+   IDE-style dark popup instead of CodeMirror's default light tooltip. */
+.cm-tooltip {
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  box-shadow: var(--shadow-lg);
+  color: var(--fg);
+  overflow: hidden;
+}
+.cm-tooltip.cm-tooltip-autocomplete {
+  margin-top: 4px;
+}
+.cm-tooltip.cm-tooltip-autocomplete > ul {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  max-height: 16em;
+  min-width: 230px;
+  padding: 4px;
+}
+.cm-tooltip.cm-tooltip-autocomplete > ul > li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 26px;
+  padding: 0 8px;
+  border-radius: 5px;
+  color: var(--fg);
+}
+.cm-tooltip-autocomplete > ul > li[aria-selected] {
+  background: color-mix(in oklch, var(--accent) 22%, transparent);
+  color: var(--fg);
+}
+/* Kind glyph — a small rounded badge, coloured by completion type. */
+.cm-completionIcon {
+  width: 16px;
+  height: 16px;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  border-radius: 4px;
+  opacity: 1;
+  padding: 0;
+}
+.cm-completionIcon::after { content: "•"; }
+.cm-completionIcon-property {
+  color: var(--layer-lemma);
+  background: color-mix(in oklch, var(--layer-lemma) 18%, transparent);
+}
+.cm-completionIcon-property::after { content: "A"; }
+.cm-completionIcon-enum {
+  color: var(--layer-pos);
+  background: color-mix(in oklch, var(--layer-pos) 18%, transparent);
+}
+.cm-completionIcon-enum::after { content: "#"; }
+.cm-completionLabel { color: inherit; flex: 1; }
+.cm-completionMatchedText {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 700;
+}
+.cm-completionDetail {
+  margin-left: auto;
+  padding-left: 12px;
+  font-style: normal;
+  font-size: 11px;
+  color: var(--fg-subtle);
+}
+/* Doc side-panel for the focused completion. */
+.cm-tooltip.cm-completionInfo {
+  margin: -1px 0 0 8px;
+  padding: 10px 12px;
+  max-width: 280px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+  border-radius: 8px;
+}
+/* Lint hover tooltip. */
+.cm-tooltip.cm-tooltip-lint { padding: 0; }
+.cm-diagnostic {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 7px 11px;
+  white-space: normal;
+  max-width: 320px;
+}
+.cm-diagnostic-error { border-left: 3px solid var(--danger); }
 .cx-input::placeholder { color: var(--fg-subtle); }
 .cx-input:focus { border-color: var(--accent); box-shadow: 0 0 0 2px color-mix(in oklch, var(--accent) 40%, transparent); }
 .cx-input-icon {

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -316,16 +316,9 @@
 /* The layer toggle doesn't apply to a CQL query (it sets layers per token). */
 .cx-layer-toggle.is-muted { opacity: 0.4; }
 
-/* Inline query (CQL parse) error, shown under the query bar. */
-.cx-query-error {
-  display: flex; align-items: center; gap: 8px;
-  padding: 7px 14px;
-  background: color-mix(in oklch, var(--danger) 14%, var(--bg-raised));
-  border-bottom: 1px solid color-mix(in oklch, var(--danger) 40%, transparent);
-  color: var(--fg);
-  font-family: var(--font-mono); font-size: 12px;
-}
-.cx-query-error .label { color: var(--danger); font-weight: 600; }
+/* Query errors are shown inline in the editor (squiggle + hover); the
+   suffix just flags the state at a glance, full message on hover. */
+.cx-suffix-error { color: var(--danger); font-weight: 600; cursor: help; }
 .cx-layer {
   border: 0; background: transparent;
   font-family: var(--font-mono); font-size: 12px; color: var(--fg-muted);

--- a/app/src/lib/cqlLang.ts
+++ b/app/src/lib/cqlLang.ts
@@ -17,6 +17,44 @@ export const POS_TAGS = [
   "PRP", "PRP$", "WP", "WDT", "MD", "TO", "UH", "FW",
 ] as const;
 
+/** A completion candidate with JetBrains-style detail + doc. */
+export interface CqlCompletion {
+  label: string;
+  /** Short type shown right-aligned (e.g. "layer", "POS"). */
+  detail: string;
+  /** Longer description shown in the side panel. */
+  info: string;
+}
+
+/** Attribute completions (with aliases), richest first. */
+export const ATTR_COMPLETIONS: CqlCompletion[] = [
+  { label: "word", detail: "layer", info: "Surface form of the token (case-insensitive)." },
+  { label: "lemma", detail: "layer", info: "Dictionary form. Requires an annotated corpus." },
+  { label: "pos", detail: "layer", info: "Part-of-speech tag, e.g. NN, VBD (case-sensitive)." },
+  { label: "hw", detail: "alias → lemma", info: "Headword — alias for lemma." },
+  { label: "tag", detail: "alias → pos", info: "Alias for pos." },
+];
+
+/** Penn-Treebank tag → human label, for POS value completion + docs. */
+export const POS_LABELS: Record<string, string> = {
+  NN: "noun, singular", NNS: "noun, plural", NNP: "proper noun, singular",
+  NNPS: "proper noun, plural", VB: "verb, base form", VBD: "verb, past tense",
+  VBG: "verb, gerund/present participle", VBN: "verb, past participle",
+  VBP: "verb, non-3rd person singular present", VBZ: "verb, 3rd person singular present",
+  JJ: "adjective", JJR: "adjective, comparative", JJS: "adjective, superlative",
+  RB: "adverb", RBR: "adverb, comparative", RBS: "adverb, superlative",
+  DT: "determiner", IN: "preposition / subordinating conjunction",
+  CC: "coordinating conjunction", CD: "cardinal number", PRP: "personal pronoun",
+  "PRP$": "possessive pronoun", WP: "wh-pronoun", WDT: "wh-determiner",
+  MD: "modal", TO: "to", UH: "interjection", FW: "foreign word",
+};
+
+export const POS_COMPLETIONS: CqlCompletion[] = POS_TAGS.map((t) => ({
+  label: t,
+  detail: "POS",
+  info: POS_LABELS[t] ?? "part-of-speech tag",
+}));
+
 export type TokenKind = "bracket" | "attr" | "operator" | "string" | "regex" | "invalid";
 
 export interface CqlToken {


### PR DESCRIPTION
Follow-up polish to the CQL editor (#55), from live feedback.

## Dark, IDE-style completion popup
The dropdown rendered in CodeMirror's *light* base theme (white bg, blue selection) because the editor theme wasn't flagged dark. Now `{ dark: true }` + a proper popup:
- dark popup matching the app (rounded, shadowed, accent-tinted selection);
- per-kind icon badges (teal `A` attributes, purple `#` POS);
- accent-bold matched text, right-aligned type `detail`, and a doc side-panel;
- rich completions: each attribute/POS option carries a `detail` (layer / alias / POS) + an `info` description (e.g. "noun, singular").

## Errors inline, not in a banner
Removed the separate `cx-query-error` window below the input. Errors now show like a real editor:
- offending span gets a red wavy underline (client parse errors are precise; squiggle + hover shows the message);
- backend exec errors feed the same CodeMirror lint system (state field + `forceLinting`), spanning the whole query;
- the input suffix flags the state at a glance ("error", full message on hover).

## Don't query invalid CQL
Typing autocloses quotes, briefly making `[pos=""]` — the app was round-tripping that to the backend, producing a transient "kwic failed: empty value" that could stick to a subsequently-valid query (the reported bug). Client-invalid CQL is now flagged inline only; we skip the backend call and keep the last results until the query parses.

## Verification
- 84 vitest + `tsc`/`vite build` green.
- Statically previewed the popup styling and screenshotted the inline error (squiggle + suffix marker). Live-verified in the dev server during iteration.

Also filed from this session: #58 theming, #59 CI perf benchmarks, #61 register-now-build-later.