### PR TITLE
Theme system: code-editor palettes, light + dark, app-wide

### DIFF
--- a/app/src/components/analyses/SettingsView.tsx
+++ b/app/src/components/analyses/SettingsView.tsx
@@ -1,10 +1,16 @@
 import { useState } from "react";
+import { THEMES, applyTheme, loadTheme } from "@/lib/theme";
 
 export function SettingsView() {
   const [ann, setAnn] = useState(true);
   const [annotator, setAnnotator] = useState("treetagger");
-  const [theme, setTheme] = useState("dark");
+  const [theme, setTheme] = useState(loadTheme);
   const [ligs, setLigs] = useState(false);
+
+  const onTheme = (id: string) => {
+    setTheme(id);
+    applyTheme(id);
+  };
 
   return (
     <div className="cx-settings">
@@ -14,13 +20,24 @@ export function SettingsView() {
       <div className="cx-setting-group">
         <div className="cx-setting-label">
           theme
-          <span className="desc">dark is tuned for long reading sessions.</span>
+          <span className="desc">applies app-wide — UI, query editor, and all.</span>
         </div>
         <div className="cx-setting-control">
-          <select className="cx-select" value={theme} onChange={(e) => setTheme(e.target.value)}>
-            <option value="dark">dark</option>
-            <option value="light">light</option>
-            <option value="system">follow system</option>
+          <select className="cx-select" value={theme} onChange={(e) => onTheme(e.target.value)}>
+            <optgroup label="Dark">
+              {THEMES.filter((t) => t.dark).map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="Light">
+              {THEMES.filter((t) => !t.dark).map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </optgroup>
           </select>
         </div>
       </div>

--- a/app/src/components/query/CqlInput.tsx
+++ b/app/src/components/query/CqlInput.tsx
@@ -34,6 +34,7 @@ import {
   tokenizeCql,
   validateCql,
 } from "@/lib/cqlLang";
+import { THEME_EVENT, currentThemeId, isThemeDark } from "@/lib/theme";
 
 export interface CqlInputProps {
   value: string;
@@ -129,8 +130,10 @@ function cqlCompletion(ctx: CompletionContext): CompletionResult | null {
  *  newline (e.g. paste of multi-line text collapses to nothing extra). */
 const singleLine = EditorState.transactionFilter.of((tr) => (tr.newDoc.lines > 1 ? [] : tr));
 
-/** Editor chrome matched to `.cx-input` (34px, inset bg, accent focus). */
-const theme = EditorView.theme({
+/** Editor chrome matched to `.cx-input` (34px, inset bg, accent focus).
+ *  Colours come from CSS variables, so it follows the active app theme;
+ *  the `dark` flag (CM base chrome) is supplied per-theme by `makeTheme`. */
+const THEME_SPEC = {
   "&": {
     flex: "1",
     minWidth: "0",
@@ -159,7 +162,11 @@ const theme = EditorView.theme({
   "&.cm-focused .cm-selectionBackground, ::selection": {
     background: "color-mix(in oklch, var(--accent) 30%, transparent)",
   },
-}, { dark: true }); // tell CodeMirror this is a dark theme → dark popups/selection
+};
+
+/** Build the editor theme with the right `dark` flag for CM's base chrome
+ *  (completion popup, selection) so light themes don't get dark popups. */
+const makeTheme = (dark: boolean) => EditorView.theme(THEME_SPEC, { dark });
 
 export function CqlInput({ value, onChange, onRun, disabled, placeholder, className, error }: CqlInputProps) {
   const host = useRef<HTMLDivElement | null>(null);
@@ -171,6 +178,7 @@ export function CqlInput({ value, onChange, onRun, disabled, placeholder, classN
   onRunRef.current = onRun;
   const placeholderComp = useRef(new Compartment());
   const editableComp = useRef(new Compartment());
+  const themeComp = useRef(new Compartment());
 
   // Build the editor once.
   useEffect(() => {
@@ -194,7 +202,7 @@ export function CqlInput({ value, onChange, onRun, disabled, placeholder, classN
         externalErrorField,
         cqlLinter,
         singleLine,
-        theme,
+        themeComp.current.of(makeTheme(isThemeDark(currentThemeId()))),
         placeholderComp.current.of(cmPlaceholder(placeholder ?? "")),
         editableComp.current.of([
           EditorView.editable.of(!disabled),
@@ -247,6 +255,18 @@ export function CqlInput({ value, onChange, onRun, disabled, placeholder, classN
     v.dispatch({ effects: setExternalError.of(error ?? null) });
     forceLinting(v);
   }, [error]);
+
+  // Follow the app theme: reconfigure CM's base `dark` flag so light
+  // themes get light popups/selection (colours already flow via CSS vars).
+  useEffect(() => {
+    const onTheme = () => {
+      view.current?.dispatch({
+        effects: themeComp.current.reconfigure(makeTheme(isThemeDark(currentThemeId()))),
+      });
+    };
+    window.addEventListener(THEME_EVENT, onTheme);
+    return () => window.removeEventListener(THEME_EVENT, onTheme);
+  }, []);
 
   return <div ref={host} className={className} />;
 }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -80,6 +80,111 @@
   --dur-3: 280ms;  /* large overlays */
 }
 
+/* ============================================================
+ * Themes — each overrides the colour tokens only (fonts / spacing /
+ * motion stay shared). Selected via `data-theme` on <html>; the default
+ * (`corpust`) is the :root palette above. All surfaces, including the
+ * CodeMirror editor, read these variables, so switching is instant.
+ * ============================================================ */
+:root[data-theme="onedark"] {
+  --bg: #282c34; --bg-raised: #2c313a; --bg-inset: #21252b; --bg-accent: #3a3f4b;
+  --fg: #abb2bf; --fg-muted: #828997; --fg-subtle: #5c6370;
+  --border: #353b45; --border-strong: #4b5263;
+  --accent: #61afef; --accent-hover: #74b9f0; --accent-fg: #1b1f27;
+  --danger: #e06c75; --success: #98c379; --info: #61afef; --warn: #e5c07b;
+  --layer-word: #61afef; --layer-lemma: #56b6c2; --layer-pos: #c678dd;
+}
+:root[data-theme="monokai"] {
+  --bg: #272822; --bg-raised: #2d2e27; --bg-inset: #1f201b; --bg-accent: #3e3d32;
+  --fg: #f8f8f2; --fg-muted: #c5c5bd; --fg-subtle: #75715e;
+  --border: #3b3c35; --border-strong: #54564a;
+  --accent: #a6e22e; --accent-hover: #b6e94f; --accent-fg: #1f201b;
+  --danger: #f92672; --success: #a6e22e; --info: #66d9ef; --warn: #e6db74;
+  --layer-word: #fd971f; --layer-lemma: #66d9ef; --layer-pos: #ae81ff;
+}
+:root[data-theme="dracula"] {
+  --bg: #282a36; --bg-raised: #2d2f3d; --bg-inset: #21222c; --bg-accent: #44475a;
+  --fg: #f8f8f2; --fg-muted: #c7c9d6; --fg-subtle: #6272a4;
+  --border: #3a3c4e; --border-strong: #4d5066;
+  --accent: #bd93f9; --accent-hover: #caa9fa; --accent-fg: #282a36;
+  --danger: #ff5555; --success: #50fa7b; --info: #8be9fd; --warn: #f1fa8c;
+  --layer-word: #8be9fd; --layer-lemma: #50fa7b; --layer-pos: #ff79c6;
+}
+:root[data-theme="nord"] {
+  --bg: #2e3440; --bg-raised: #343b4a; --bg-inset: #272c36; --bg-accent: #3b4252;
+  --fg: #eceff4; --fg-muted: #c2cbd9; --fg-subtle: #7b88a1;
+  --border: #3b4252; --border-strong: #4c566a;
+  --accent: #88c0d0; --accent-hover: #8fbcbb; --accent-fg: #2e3440;
+  --danger: #bf616a; --success: #a3be8c; --info: #81a1c1; --warn: #ebcb8b;
+  --layer-word: #88c0d0; --layer-lemma: #8fbcbb; --layer-pos: #b48ead;
+}
+:root[data-theme="gruvbox"] {
+  --bg: #282828; --bg-raised: #32302f; --bg-inset: #1d2021; --bg-accent: #3c3836;
+  --fg: #ebdbb2; --fg-muted: #bdae93; --fg-subtle: #928374;
+  --border: #3c3836; --border-strong: #504945;
+  --accent: #fe8019; --accent-hover: #ff9b4c; --accent-fg: #1d2021;
+  --danger: #fb4934; --success: #b8bb26; --info: #83a598; --warn: #fabd2f;
+  --layer-word: #83a598; --layer-lemma: #8ec07c; --layer-pos: #d3869b;
+}
+:root[data-theme="tokyonight"] {
+  --bg: #1a1b26; --bg-raised: #1f2335; --bg-inset: #16161e; --bg-accent: #292e42;
+  --fg: #c0caf5; --fg-muted: #9aa5ce; --fg-subtle: #565f89;
+  --border: #2a2e42; --border-strong: #3b4261;
+  --accent: #7aa2f7; --accent-hover: #8db0f8; --accent-fg: #1a1b26;
+  --danger: #f7768e; --success: #9ece6a; --info: #7dcfff; --warn: #e0af68;
+  --layer-word: #7aa2f7; --layer-lemma: #7dcfff; --layer-pos: #bb9af7;
+}
+:root[data-theme="catppuccin"] {
+  --bg: #1e1e2e; --bg-raised: #232336; --bg-inset: #181825; --bg-accent: #313244;
+  --fg: #cdd6f4; --fg-muted: #a6adc8; --fg-subtle: #6c7086;
+  --border: #313244; --border-strong: #45475a;
+  --accent: #cba6f7; --accent-hover: #d4b6f9; --accent-fg: #1e1e2e;
+  --danger: #f38ba8; --success: #a6e3a1; --info: #89b4fa; --warn: #f9e2af;
+  --layer-word: #89b4fa; --layer-lemma: #94e2d5; --layer-pos: #cba6f7;
+}
+:root[data-theme="solarized"] {
+  --bg: #002b36; --bg-raised: #073642; --bg-inset: #002129; --bg-accent: #0a4b5a;
+  --fg: #93a1a1; --fg-muted: #839496; --fg-subtle: #586e75;
+  --border: #0a3d49; --border-strong: #11505f;
+  --accent: #2aa198; --accent-hover: #36b3aa; --accent-fg: #002b36;
+  --danger: #dc322f; --success: #859900; --info: #268bd2; --warn: #b58900;
+  --layer-word: #268bd2; --layer-lemma: #2aa198; --layer-pos: #6c71c4;
+}
+
+/* --- light themes --- */
+:root[data-theme="onelight"] {
+  --bg: #fafafa; --bg-raised: #ffffff; --bg-inset: #f0f0f1; --bg-accent: #e5e5e6;
+  --fg: #383a42; --fg-muted: #696c77; --fg-subtle: #a0a1a7;
+  --border: #e1e1e2; --border-strong: #c9c9cb;
+  --accent: #4078f2; --accent-hover: #2f68e6; --accent-fg: #ffffff;
+  --danger: #e45649; --success: #50a14f; --info: #4078f2; --warn: #c18401;
+  --layer-word: #4078f2; --layer-lemma: #0184bc; --layer-pos: #a626a4;
+}
+:root[data-theme="github"] {
+  --bg: #ffffff; --bg-raised: #ffffff; --bg-inset: #f6f8fa; --bg-accent: #eaeef2;
+  --fg: #1f2328; --fg-muted: #656d76; --fg-subtle: #8c959f;
+  --border: #d0d7de; --border-strong: #afb8c1;
+  --accent: #0969da; --accent-hover: #0860c9; --accent-fg: #ffffff;
+  --danger: #cf222e; --success: #1a7f37; --info: #0969da; --warn: #9a6700;
+  --layer-word: #0969da; --layer-lemma: #1b7c83; --layer-pos: #8250df;
+}
+:root[data-theme="solarized-light"] {
+  --bg: #fdf6e3; --bg-raised: #f5efdc; --bg-inset: #eee8d5; --bg-accent: #e3ddc8;
+  --fg: #586e75; --fg-muted: #657b83; --fg-subtle: #93a1a1;
+  --border: #e3ddc8; --border-strong: #d3cdb8;
+  --accent: #268bd2; --accent-hover: #1e7fc2; --accent-fg: #fdf6e3;
+  --danger: #dc322f; --success: #859900; --info: #268bd2; --warn: #b58900;
+  --layer-word: #268bd2; --layer-lemma: #2aa198; --layer-pos: #6c71c4;
+}
+:root[data-theme="latte"] {
+  --bg: #eff1f5; --bg-raised: #ffffff; --bg-inset: #e6e9ef; --bg-accent: #dce0e8;
+  --fg: #4c4f69; --fg-muted: #6c6f85; --fg-subtle: #9ca0b0;
+  --border: #dce0e8; --border-strong: #ccd0da;
+  --accent: #8839ef; --accent-hover: #7a2fe0; --accent-fg: #ffffff;
+  --danger: #d20f39; --success: #40a02b; --info: #1e66f5; --warn: #df8e1d;
+  --layer-word: #1e66f5; --layer-lemma: #179299; --layer-pos: #8839ef;
+}
+
 @layer base {
   * { box-sizing: border-box; }
   html, body, #root { height: 100%; margin: 0; }

--- a/app/src/lib/theme.test.ts
+++ b/app/src/lib/theme.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { THEME_EVENT, applyTheme, currentThemeId, isThemeDark, loadTheme } from "./theme";
+
+describe("theme", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("defaults to the original Corpust Dark", () => {
+    expect(loadTheme()).toBe("corpust");
+  });
+
+  it("applyTheme sets the attribute, persists, and fires the event", () => {
+    let fired: string | null = null;
+    window.addEventListener(THEME_EVENT, (e) => {
+      fired = (e as CustomEvent).detail;
+    }, { once: true });
+    applyTheme("onedark");
+    expect(document.documentElement.dataset.theme).toBe("onedark");
+    expect(loadTheme()).toBe("onedark");
+    expect(currentThemeId()).toBe("onedark");
+    expect(fired).toBe("onedark");
+  });
+
+  it("ignores an unknown persisted theme", () => {
+    localStorage.setItem("corpust-theme", "bogus");
+    expect(loadTheme()).toBe("corpust");
+  });
+
+  it("isThemeDark reflects metadata (defaulting to dark)", () => {
+    expect(isThemeDark("corpust")).toBe(true);
+    expect(isThemeDark("github")).toBe(false);
+    expect(isThemeDark("latte")).toBe(false);
+    expect(isThemeDark("unknown")).toBe(true);
+  });
+});

--- a/app/src/lib/theme.ts
+++ b/app/src/lib/theme.ts
@@ -1,0 +1,69 @@
+// Theme switching. A theme is just a set of CSS-variable values applied via
+// `data-theme` on <html>; every surface (incl. the CQL editor) reads those
+// variables, so switching is instant and global. Palettes live in index.css.
+//
+// `dark` drives CodeMirror's base theme flag (popup/selection chrome), which
+// the editor reconfigures on the `corpust-theme` event below.
+
+export interface Theme {
+  id: string;
+  name: string;
+  dark: boolean;
+}
+
+/** Built-in themes — popular code-editor palettes. Each `id` has a matching
+ *  `:root[data-theme="<id>"]` block in index.css. */
+export const THEMES: Theme[] = [
+  { id: "corpust", name: "Corpust Dark", dark: true },
+  { id: "onedark", name: "One Dark", dark: true },
+  { id: "monokai", name: "Monokai", dark: true },
+  { id: "dracula", name: "Dracula", dark: true },
+  { id: "nord", name: "Nord", dark: true },
+  { id: "gruvbox", name: "Gruvbox Dark", dark: true },
+  { id: "tokyonight", name: "Tokyo Night", dark: true },
+  { id: "catppuccin", name: "Catppuccin Mocha", dark: true },
+  { id: "solarized", name: "Solarized Dark", dark: true },
+  { id: "onelight", name: "One Light", dark: false },
+  { id: "github", name: "GitHub Light", dark: false },
+  { id: "solarized-light", name: "Solarized Light", dark: false },
+  { id: "latte", name: "Catppuccin Latte", dark: false },
+];
+
+const STORAGE_KEY = "corpust-theme";
+const DEFAULT_THEME = "corpust";
+
+/** Event fired (on window) when the theme changes, so non-React surfaces
+ *  like the CodeMirror editor can react. */
+export const THEME_EVENT = "corpust-theme";
+
+/** The persisted theme id, or the default when unset/unknown. */
+export function loadTheme(): string {
+  try {
+    const id = localStorage.getItem(STORAGE_KEY);
+    if (id && THEMES.some((t) => t.id === id)) return id;
+  } catch {
+    // localStorage unavailable (private mode / non-browser) — use default.
+  }
+  return DEFAULT_THEME;
+}
+
+/** Apply a theme: set `data-theme` on <html>, persist, and notify. */
+export function applyTheme(id: string): void {
+  document.documentElement.dataset.theme = id;
+  try {
+    localStorage.setItem(STORAGE_KEY, id);
+  } catch {
+    // ignore persistence failures
+  }
+  window.dispatchEvent(new CustomEvent(THEME_EVENT, { detail: id }));
+}
+
+/** The currently-applied theme id (from the DOM, falling back to storage). */
+export function currentThemeId(): string {
+  return document.documentElement.dataset.theme || loadTheme();
+}
+
+/** Whether a theme is dark (defaults to dark for unknown ids). */
+export function isThemeDark(id: string): boolean {
+  return THEMES.find((t) => t.id === id)?.dark ?? true;
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
+import { loadTheme } from "./lib/theme";
 import "./index.css";
+
+// Apply the saved theme before first paint to avoid a flash.
+document.documentElement.dataset.theme = loadTheme();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
Closes #58. Real, switchable themes applied **app-wide** — UI chrome, query editor, completion popups, KWIC, everything. A theme is just a set of CSS-variable values applied via `data-theme` on `<html>`; all surfaces read those tokens, so switching is instant and global.

## Themes (13)
**Dark:** Corpust Dark (default — our original palette), One Dark, Monokai, Dracula, Nord, Gruvbox Dark, Tokyo Night, Catppuccin Mocha, Solarized Dark.
**Light:** One Light, GitHub Light, Solarized Light, Catppuccin Latte.

## How it works
- `lib/theme.ts` — `THEMES`, `loadTheme`/`applyTheme` (persisted to localStorage) + a `corpust-theme` event for non-React surfaces.
- `main.tsx` applies the saved theme before first paint (no flash).
- Palettes are `:root[data-theme="<id>"]` blocks overriding only the colour tokens (fonts/spacing/motion stay shared).
- **Settings** gets a real theme picker (Dark/Light optgroups), replacing the old dummy select.
- The **CQL editor** follows the theme: its colours already come from CSS vars, and its CodeMirror base `dark` flag reconfigures on theme change so light themes get light popups/selection.

Default stays **Corpust Dark**.

## Verification
- 88 vitest (added `theme.test.ts`: default / apply+persist+event / unknown-id fallback / dark-flag) + `tsc`/`vite build` green.
- Screenshotted One Dark (dark) and GitHub Light (light) — the whole app, including the query editor, flips correctly. (A dark title-strip in the light screenshot was a headless-only `backdrop-filter` artifact, verified — renders correctly in the real WebView.)

Follow-up: user-defined custom themes (the picker + token system are the foundation); a couple of light themes deferred only by taste.